### PR TITLE
Support custom domain settings

### DIFF
--- a/cloudformation/bin/stack.sh
+++ b/cloudformation/bin/stack.sh
@@ -33,7 +33,6 @@ put_stack() {
       --template-url ${CF_TEMPLATE_URL} \
       --capabilities CAPABILITY_IAM \
       --parameters \
-        ParameterKey=ServiceName,ParameterValue=${SERVICE_NAME},UsePreviousValue=false \
         ParameterKey=UserName,ParameterValue=${USER_NAME},UsePreviousValue=false \
         ParameterKey=UserEmail,ParameterValue=${USER_EMAIL},UsePreviousValue=false
 }

--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -623,8 +623,8 @@ Resources:
       MemorySize: 128
       Role:
         Fn::GetAtt:
-          - "LambdaRole"
-          - "Arn"
+          - CognitoHandleFunctionRole
+          - Arn
       Runtime: "nodejs4.3"
       Timeout: 30
   PatchSettingsLambdaInvokePermission:
@@ -2896,7 +2896,7 @@ Resources:
       MemorySize: 128
       Role:
         Fn::GetAtt:
-          - LambdaRole
+          - CognitoHandleFunctionRole
           - Arn
       Runtime: "nodejs4.3"
       Timeout: 30
@@ -2935,6 +2935,8 @@ Resources:
         Fn::GetAtt:
           - DBCreateItemsLambdaFunction
           - Arn
+      CognitoPoolID: !Sub |-
+        ${CognitoUserPool.UserPoolID}
       AdminPageURL: !Sub |-
         https://${AdminPageDistribution.DomainName}
       StatusPageURL: !Sub |-

--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -540,6 +540,105 @@ Resources:
       Principal: "apigateway.amazonaws.com"
       SourceArn: !Sub |-
         arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/GET/maintenances/{maintenanceid}/maintenanceupdates
+  GetSettingsLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Sub |-
+          lambstatus-${AWS::Region}
+        S3Key: !Sub
+          - fn/${Version}/GetSettings.zip
+          - Version:
+              Fn::FindInMap: [ Constants, LambStatus, Version ]
+      Description: "Get settings"
+      # The prefix of function name must be stack name
+      FunctionName: !Sub |-
+        ${AWS::StackName}-GetSettings
+      Handler: "_apex_index.handle"
+      MemorySize: 128
+      Role:
+        Fn::GetAtt:
+          - "LambdaRole"
+          - "Arn"
+      Runtime: "nodejs4.3"
+      Timeout: 30
+  GetSettingsLambdaInvokePermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName:
+        Fn::GetAtt:
+          - "GetSettingsLambdaFunction"
+          - "Arn"
+      Action: "lambda:InvokeFunction"
+      Principal: "apigateway.amazonaws.com"
+      SourceArn: !Sub |-
+        arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/GET/settings
+  GetPublicSettingsLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Sub |-
+          lambstatus-${AWS::Region}
+        S3Key: !Sub
+          - fn/${Version}/GetPublicSettings.zip
+          - Version:
+              Fn::FindInMap: [ Constants, LambStatus, Version ]
+      Description: "Get settings"
+      # The prefix of function name must be stack name
+      FunctionName: !Sub |-
+        ${AWS::StackName}-GetPublicSettings
+      Handler: "_apex_index.handle"
+      MemorySize: 128
+      Role:
+        Fn::GetAtt:
+          - "LambdaRole"
+          - "Arn"
+      Runtime: "nodejs4.3"
+      Timeout: 30
+  GetPublicSettingsLambdaInvokePermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName:
+        Fn::GetAtt:
+          - "GetPublicSettingsLambdaFunction"
+          - "Arn"
+      Action: "lambda:InvokeFunction"
+      Principal: "apigateway.amazonaws.com"
+      SourceArn: !Sub |-
+        arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/GET/public-settings
+  PatchSettingsLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Sub |-
+          lambstatus-${AWS::Region}
+        S3Key: !Sub
+          - fn/${Version}/PatchSettings.zip
+          - Version:
+              Fn::FindInMap: [ Constants, LambStatus, Version ]
+      Description: "Patch settings"
+      # The prefix of function name must be stack name
+      FunctionName: !Sub |-
+        ${AWS::StackName}-PatchSettings
+      Handler: "_apex_index.handle"
+      MemorySize: 128
+      Role:
+        Fn::GetAtt:
+          - "LambdaRole"
+          - "Arn"
+      Runtime: "nodejs4.3"
+      Timeout: 30
+  PatchSettingsLambdaInvokePermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      FunctionName:
+        Fn::GetAtt:
+          - "PatchSettingsLambdaFunction"
+          - "Arn"
+      Action: "lambda:InvokeFunction"
+      Principal: "apigateway.amazonaws.com"
+      SourceArn: !Sub |-
+        arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/PATCH/settings
   GetExternalMetricsLambdaFunction:
     Type: "AWS::Lambda::Function"
     Properties:

--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -2758,6 +2758,13 @@ Resources:
                   - cognito-idp:*
                   - iam:PassRole
                 Resource: '*'
+        - PolicyName: HandleSettings
+          PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action: "dynamodb:*"
+                Resource: !Sub |-
+                  arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${SettingsTable}
   CognitoCreateUserPoolFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -2929,9 +2936,9 @@ Resources:
           - DBCreateItemsLambdaFunction
           - Arn
       AdminPageURL: !Sub |-
-        "https://${AdminPageDistribution.DomainName}"
+        https://${AdminPageDistribution.DomainName}
       StatusPageURL: !Sub |-
-        "https://${StatusPageDistribution.DomainName}"
+        https://${StatusPageDistribution.DomainName}
   StatusPageFrontend:
     Type: Custom::S3SyncObjects
     Properties:

--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -2,11 +2,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: "AWS resources for serverless status pages"
 Parameters:
-  ServiceName:
-    Description: Your service name
-    Type: String
-    Default: MyService
-    MinLength: 1
   UserName:
     Description: Your user name
     Type: String
@@ -2250,6 +2245,196 @@ Resources:
             method.response.header.Access-Control-Allow-Headers: true
             method.response.header.Access-Control-Allow-Methods: true
             method.response.header.Access-Control-Allow-Origin: true
+  PublicSettingsApiResource:
+    Type: "AWS::ApiGateway::Resource"
+    Properties:
+      RestApiId:
+        Ref: "RestApi"
+      ParentId:
+        Fn::GetAtt:
+          - "RestApi"
+          - "RootResourceId"
+      PathPart: "public-settings"
+  GetPublicSettingsApiMethod:
+    Type: "AWS::ApiGateway::Method"
+    Properties:
+      RestApiId:
+        Ref: "RestApi"
+      ResourceId:
+        Ref: "PublicSettingsApiResource"
+      HttpMethod: "GET"
+      AuthorizationType: "NONE"
+      ApiKeyRequired: false
+      Integration:
+        Type: "AWS"
+        IntegrationHttpMethod: "POST"
+        Uri: !Sub
+          - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function}/invocations
+          - Function:
+              Fn::GetAtt:
+                - "GetPublicSettingsLambdaFunction"
+                - "Arn"
+        IntegrationResponses:
+          - StatusCode: "200"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+          - StatusCode: "400"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+            SelectionPattern: ".*Error.*"
+      MethodResponses:
+        - StatusCode: "200"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Origin: true
+        - StatusCode: "400"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Origin: true
+  OptionsPublicSettingsApiMethod:
+    Type: "AWS::ApiGateway::Method"
+    Properties:
+      RestApiId:
+        Ref: "RestApi"
+      ResourceId:
+        Ref: "PublicSettingsApiResource"
+      HttpMethod: "OPTIONS"
+      AuthorizationType: "NONE"
+      ApiKeyRequired: false
+      Integration:
+        Type: "MOCK"
+        RequestTemplates:
+          application/json: "{ \"statusCode\": 200 }"
+        IntegrationResponses:
+          - StatusCode: "200"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Requested-With,X-Requested-By,X-Api-Key'"
+              method.response.header.Access-Control-Allow-Methods: "'GET,OPTIONS'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+      MethodResponses:
+        - StatusCode: "200"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: true
+            method.response.header.Access-Control-Allow-Methods: true
+            method.response.header.Access-Control-Allow-Origin: true
+  SettingsApiResource:
+    Type: "AWS::ApiGateway::Resource"
+    Properties:
+      RestApiId:
+        Ref: "RestApi"
+      ParentId:
+        Fn::GetAtt:
+          - "RestApi"
+          - "RootResourceId"
+      PathPart: "settings"
+  GetSettingsApiMethod:
+    Type: "AWS::ApiGateway::Method"
+    Properties:
+      RestApiId:
+        Ref: "RestApi"
+      ResourceId:
+        Ref: "SettingsApiResource"
+      HttpMethod: "GET"
+      AuthorizationType: "COGNITO_USER_POOLS"
+      AuthorizerId:
+        Ref: "Authorizer"
+      ApiKeyRequired: false
+      Integration:
+        Type: "AWS"
+        IntegrationHttpMethod: "POST"
+        Uri: !Sub
+          - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function}/invocations
+          - Function:
+              Fn::GetAtt:
+                - "GetSettingsLambdaFunction"
+                - "Arn"
+        IntegrationResponses:
+          - StatusCode: "200"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+          - StatusCode: "400"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+            SelectionPattern: ".*Error.*"
+      MethodResponses:
+        - StatusCode: "200"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Origin: true
+        - StatusCode: "400"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Origin: true
+  PatchSettingsApiMethod:
+    Type: "AWS::ApiGateway::Method"
+    Properties:
+      RestApiId:
+        Ref: "RestApi"
+      ResourceId:
+        Ref: "SettingsApiResource"
+      HttpMethod: "PATCH"
+      AuthorizationType: "COGNITO_USER_POOLS"
+      AuthorizerId:
+        Ref: "Authorizer"
+      ApiKeyRequired: false
+      Integration:
+        Type: "AWS"
+        IntegrationHttpMethod: "POST"
+        PassthroughBehavior: "WHEN_NO_TEMPLATES"
+        RequestTemplates:
+          application/json: !Sub |-
+            {
+              "body":$input.json('$'),
+              "params":{
+                #foreach($param in $input.params().path.keySet())
+                "$param": "$util.escapeJavaScript($input.params().path.get($param))"
+                #if($foreach.hasNext),#end
+                #end
+              }
+            }
+        Uri: !Sub
+          - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Function}/invocations
+          - Function:
+              Fn::GetAtt:
+                - "PatchSettingsLambdaFunction"
+                - "Arn"
+        IntegrationResponses:
+          - StatusCode: "200"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+          - StatusCode: "400"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+            SelectionPattern: ".*Error.*"
+      MethodResponses:
+        - StatusCode: "200"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Origin: true
+        - StatusCode: "400"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Origin: true
+  OptionsSettingsApiMethod:
+    Type: "AWS::ApiGateway::Method"
+    Properties:
+      RestApiId:
+        Ref: "RestApi"
+      ResourceId:
+        Ref: "SettingsApiResource"
+      HttpMethod: "OPTIONS"
+      AuthorizationType: "NONE"
+      ApiKeyRequired: false
+      Integration:
+        Type: "MOCK"
+        RequestTemplates:
+          application/json: "{ \"statusCode\": 200 }"
+        IntegrationResponses:
+          - StatusCode: "200"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Requested-With,X-Requested-By,X-Api-Key'"
+              method.response.header.Access-Control-Allow-Methods: "'GET,PATCH,OPTIONS'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+      MethodResponses:
+        - StatusCode: "200"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: true
+            method.response.header.Access-Control-Allow-Methods: true
+            method.response.header.Access-Control-Allow-Origin: true
   StatusPageS3:
     Type: "AWS::S3::Bucket"
     Properties:
@@ -2667,6 +2852,28 @@ Resources:
                   - apigateway:POST
                 Resource: !Sub |-
                   arn:aws:apigateway:${AWS::Region}::/restapis/${RestApi}/deployments
+  DBCreateItemsLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: !Sub |-
+          lambstatus-${AWS::Region}
+        S3Key: !Sub
+          - fn/${Version}/DBCreateItems.zip
+          - Version:
+              Fn::FindInMap: [ Constants, LambStatus, Version ]
+      Description: "Create items"
+      # The prefix of function name must be stack name
+      FunctionName: !Sub |-
+        ${AWS::StackName}-DBCreateItems
+      Handler: "_apex_index.handle"
+      MemorySize: 128
+      Role:
+        Fn::GetAtt:
+          - LambdaRole
+          - Arn
+      Runtime: "nodejs4.3"
+      Timeout: 30
   StatusPageApiInfo:
     Type: Custom::S3PutObject
     Properties:
@@ -2680,7 +2887,7 @@ Resources:
         Ref: StatusPageS3
       Key: settings.json
       Body: !Sub |-
-        {"InvocationURL": "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/prod/", "ServiceName": "${ServiceName}", "StatusPageURL": "https://${StatusPageDistribution.DomainName}"}
+        {"InvocationURL": "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/prod/"}
   AdminPageApiInfo:
     Type: Custom::S3PutObject
     Properties:
@@ -2694,7 +2901,18 @@ Resources:
         Ref: AdminPageS3
       Key: settings.json
       Body: !Sub |-
-        {"InvocationURL": "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/prod/", "ServiceName": "${ServiceName}", "StatusPageURL": "https://${StatusPageDistribution.DomainName}", "UserPoolID": "${CognitoUserPool.UserPoolID}", "ClientID": "${CognitoUserPoolClient.UserPoolClientID}"}
+        {"InvocationURL": "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/prod/", "UserPoolID": "${CognitoUserPool.UserPoolID}", "ClientID": "${CognitoUserPoolClient.UserPoolClientID}"}
+  DBInitialItems:
+    Type: Custom::DBCreateItems
+    Properties:
+      ServiceToken:
+        Fn::GetAtt:
+          - DBCreateItemsLambdaFunction
+          - Arn
+      AdminPageURL: !Sub |-
+        "https://${AdminPageDistribution.DomainName}"
+      StatusPageURL: !Sub |-
+        "https://${StatusPageDistribution.DomainName}"
   StatusPageFrontend:
     Type: Custom::S3SyncObjects
     Properties:
@@ -2757,8 +2975,6 @@ Resources:
         ${AWS::Region}
       PoolName: !Sub |-
         ${AWS::StackName}
-      ServiceName: !Sub |-
-        ${ServiceName}
       AdminPageURL: !Sub |-
         https://${AdminPageDistribution.DomainName}
       SnsCallerArn: !Sub |-

--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -71,6 +71,10 @@ Resources:
             Action: "dynamodb:*"
             Resource: !Sub |-
               arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${MetricsTable}
+          - Effect: "Allow"
+            Action: "dynamodb:*"
+            Resource: !Sub |-
+              arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${SettingsTable}
       Roles:
         - Ref: "LambdaRole"
   GetComponentsLambdaFunction:
@@ -2637,6 +2641,21 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: "1"
         WriteCapacityUnits: "1"
+  SettingsTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      # The prefix of table name must be stack name
+      TableName: !Sub |-
+        ${AWS::StackName}-SettingsTable
+      AttributeDefinitions:
+        - AttributeName: "key"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "key"
+          KeyType: "HASH"
+      ProvisionedThroughput:
+        ReadCapacityUnits: "1"
+        WriteCapacityUnits: "1"
   S3HandleFunctionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -3015,6 +3034,8 @@ Resources:
         - ${Version}
         - Version:
             Fn::FindInMap: [ Constants, LambStatus, Version ]
+    DependsOn:
+      - ApiDeployment
 Outputs:
   LambdaRoleArn:
     Value:

--- a/packages/frontend/bin/fetch-settings.js
+++ b/packages/frontend/bin/fetch-settings.js
@@ -41,20 +41,6 @@ const findOutputKey = (outputs, outputKey) => {
   return outputValue
 }
 
-const findParameterKey = (params, paramKey) => {
-  let paramValue
-  params.forEach((param) => {
-    if (param.ParameterKey === paramKey) {
-      paramValue = param.ParameterValue
-      return
-    }
-  })
-  if (paramValue === undefined) {
-    throw new Error(paramKey + ' not found')
-  }
-  return paramValue
-}
-
 const getSettings = async () => {
   try {
     const { STACK_NAME: stackName, AWS_REGION: region } = process.env
@@ -62,12 +48,10 @@ const getSettings = async () => {
     const stack = await describeStack(cloudFormation, stackName)
 
     const invocationURL = findOutputKey(stack.Outputs, 'InvocationURL')
-    const statusPageURL = findOutputKey(stack.Outputs, 'StatusPageCloudFrontURL')
-    const serviceName = findParameterKey(stack.Parameters, 'ServiceName')
     const userPoolID = findOutputKey(stack.Outputs, 'UserPoolID')
     const clientID = findOutputKey(stack.Outputs, 'UserPoolClientID')
 
-    return { invocationURL, statusPageURL, serviceName, userPoolID, clientID }
+    return { invocationURL, userPoolID, clientID }
   } catch (error) {
     console.error(error, error.stack)
     throw error
@@ -93,12 +77,10 @@ const getBucketInfo = async () => {
 }
 
 getSettings().then((
-  { invocationURL, statusPageURL, serviceName, userPoolID, clientID }
+  { invocationURL, userPoolID, clientID }
 ) => {
   const apiInfo = {
     InvocationURL: invocationURL,
-    StatusPageURL: statusPageURL,
-    ServiceName: serviceName,
     UserPoolID: userPoolID,
     ClientID: clientID
   }

--- a/packages/frontend/src/actions/metrics.js
+++ b/packages/frontend/src/actions/metrics.js
@@ -1,6 +1,6 @@
 import 'whatwg-fetch'
 import { sendRequest, buildHeaders } from 'utils/fetch'
-import { apiURL, statusPageURL } from 'utils/settings'
+import { apiURL } from 'utils/settings'
 
 export const LIST_METRICS = 'LIST_METRICS'
 export const LIST_EXTERNAL_METRICS = 'LIST_EXTERNAL_METRICS'
@@ -145,7 +145,7 @@ export const deleteMetric = (metricID, callbacks = {}) => {
   }
 }
 
-export const fetchMetricsData = (metricID, year, month, date, callbacks = {}) => {
+export const fetchMetricsData = (statusPageURL, metricID, year, month, date, callbacks = {}) => {
   return async dispatch => {
     try {
       const respBody = await sendRequest(`${statusPageURL}/metrics/${metricID}/${year}/${month}/${date}.json`,

--- a/packages/frontend/src/actions/settings.js
+++ b/packages/frontend/src/actions/settings.js
@@ -1,0 +1,63 @@
+import 'whatwg-fetch'
+import { sendRequest, buildHeaders } from 'utils/fetch'
+import { apiURL } from 'utils/settings'
+
+export const LIST_SETTINGS = 'LIST_SETTINGS'
+export const EDIT_SETTINGS = 'EDIT_SETTINGS'
+
+export function listSettings (json) {
+  return {
+    type: LIST_SETTINGS,
+    settings: json
+  }
+}
+
+export function editSettings (json) {
+  return {
+    type: EDIT_SETTINGS,
+    settings: json
+  }
+}
+
+export const fetchSettings = (callbacks = {}) => {
+  return async dispatch => {
+    try {
+      const json = await sendRequest(apiURL + 'settings', {
+        headers: buildHeaders()
+      }, callbacks)
+      dispatch(listSettings(json))
+    } catch (error) {
+      console.error(error.message)
+      console.error(error.stack)
+    }
+  }
+}
+
+export const fetchPublicSettings = (callbacks = {}) => {
+  return async dispatch => {
+    try {
+      const json = await sendRequest(apiURL + 'public-settings', {}, callbacks)
+      dispatch(listSettings(json))
+    } catch (error) {
+      console.error(error.message)
+      console.error(error.stack)
+    }
+  }
+}
+
+export const updateSettings = (serviceName, adminPageURL, statusPageURL, callbacks = {}) => {
+  return async dispatch => {
+    try {
+      const body = { serviceName, adminPageURL, statusPageURL }
+      const json = await sendRequest(apiURL + 'settings', {
+        headers: buildHeaders(),
+        method: 'PATCH',
+        body: JSON.stringify(body)
+      }, callbacks)
+      dispatch(editSettings(json))
+    } catch (error) {
+      console.error(error.message)
+      console.error(error.stack)
+    }
+  }
+}

--- a/packages/frontend/src/admin-page.js
+++ b/packages/frontend/src/admin-page.js
@@ -96,8 +96,6 @@ const timer = setInterval(() => {
     clearInterval(timer)
 
     settings.apiURL = __LAMBSTATUS_API_URL__
-    settings.serviceName = __LAMBSTATUS_SERVICE_NAME__
-    settings.statusPageURL = __LAMBSTATUS_STATUS_PAGE_URL__
     settings.userPoolId = __LAMBSTATUS_USER_POOL_ID__
     settings.clientId = __LAMBSTATUS_CLIENT_ID__
     render(routes)

--- a/packages/frontend/src/components/adminPage/Drawer/index.js
+++ b/packages/frontend/src/components/adminPage/Drawer/index.js
@@ -20,13 +20,13 @@ const components = {
     name: 'Metrics',
     path: '/metrics'
   },
-  settings: {
-    name: 'Settings',
-    path: '/settings'
-  },
   users: {
     name: 'Users',
     path: '/users'
+  },
+  settings: {
+    name: 'Settings',
+    path: '/settings'
   }
 }
 

--- a/packages/frontend/src/components/adminPage/Drawer/index.js
+++ b/packages/frontend/src/components/adminPage/Drawer/index.js
@@ -20,6 +20,10 @@ const components = {
     name: 'Metrics',
     path: '/metrics'
   },
+  settings: {
+    name: 'Settings',
+    path: '/settings'
+  },
   users: {
     name: 'Users',
     path: '/users'

--- a/packages/frontend/src/components/adminPage/Header/Header.js
+++ b/packages/frontend/src/components/adminPage/Header/Header.js
@@ -6,15 +6,17 @@ import classes from './Header.scss'
 export default class Header extends React.Component {
   static propTypes = {
     username: PropTypes.string,
-    fetchUser: PropTypes.func.isRequired,
     signout: PropTypes.func.isRequired,
     settings: PropTypes.shape({
-      statusPageURL: PropTypes.string.isRequired
-    }).isRequired
+      statusPageURL: PropTypes.string
+    }).isRequired,
+    fetchUser: PropTypes.func.isRequired,
+    fetchSettings: PropTypes.func.isRequired
   }
 
   componentDidMount () {
     this.props.fetchUser()
+    this.props.fetchSettings()
 
     let jsElem = ReactDOM.findDOMNode(this.refs.menu)
     componentHandler.upgradeElement(jsElem)

--- a/packages/frontend/src/components/adminPage/Header/Header.js
+++ b/packages/frontend/src/components/adminPage/Header/Header.js
@@ -44,7 +44,7 @@ export default class Header extends React.Component {
     const userMenu = this.renderUserMenu()
     return (<header className={classnames('mdl-layout__header', 'mdl-layout--no-drawer-button', classes.header)}>
       <div className='mdl-layout__header-row'>
-        <span className='mdl-layout-title'>LambStatus Admin</span>
+        <span className='mdl-layout-title'>{settings.serviceName}Status Admin</span>
         <div className='mdl-layout-spacer' />
         <nav className='mdl-navigation'>
           <a className={classnames('mdl-button', 'mdl-js-button', classes.nav_item)} href={settings.statusPageURL}>

--- a/packages/frontend/src/components/adminPage/Header/Header.js
+++ b/packages/frontend/src/components/adminPage/Header/Header.js
@@ -1,14 +1,16 @@
 import React, { PropTypes } from 'react'
 import ReactDOM from 'react-dom'
 import classnames from 'classnames'
-import { statusPageURL } from 'utils/settings'
 import classes from './Header.scss'
 
 export default class Header extends React.Component {
   static propTypes = {
     username: PropTypes.string,
     fetchUser: PropTypes.func.isRequired,
-    signout: PropTypes.func.isRequired
+    signout: PropTypes.func.isRequired,
+    settings: PropTypes.shape({
+      statusPageURL: PropTypes.string.isRequired
+    }).isRequired
   }
 
   componentDidMount () {
@@ -36,13 +38,14 @@ export default class Header extends React.Component {
   }
 
   render () {
+    const { settings } = this.props
     const userMenu = this.renderUserMenu()
     return (<header className={classnames('mdl-layout__header', 'mdl-layout--no-drawer-button', classes.header)}>
       <div className='mdl-layout__header-row'>
         <span className='mdl-layout-title'>LambStatus Admin</span>
         <div className='mdl-layout-spacer' />
         <nav className='mdl-navigation'>
-          <a className={classnames('mdl-button', 'mdl-js-button', classes.nav_item)} href={statusPageURL}>
+          <a className={classnames('mdl-button', 'mdl-js-button', classes.nav_item)} href={settings.statusPageURL}>
             View Status Page
           </a>
           {userMenu}

--- a/packages/frontend/src/components/adminPage/Header/index.js
+++ b/packages/frontend/src/components/adminPage/Header/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { fetchUser, signout } from 'actions/users'
+import { fetchSettings } from 'actions/settings'
 import Header from './Header'
 
 const mapStateToProps = (state) => {
@@ -11,7 +12,7 @@ const mapStateToProps = (state) => {
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({fetchUser, signout}, dispatch)
+  return bindActionCreators({fetchSettings, fetchUser, signout}, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Header)

--- a/packages/frontend/src/components/adminPage/Header/index.js
+++ b/packages/frontend/src/components/adminPage/Header/index.js
@@ -5,7 +5,8 @@ import Header from './Header'
 
 const mapStateToProps = (state) => {
   return {
-    username: state.user.user.username
+    username: state.user.user.username,
+    settings: state.settings.settings
   }
 }
 

--- a/packages/frontend/src/components/adminPage/Routes/index.js
+++ b/packages/frontend/src/components/adminPage/Routes/index.js
@@ -7,6 +7,7 @@ import Incidents from 'components/adminPage/Incidents'
 import Maintenances from 'components/adminPage/Maintenances'
 import Users from 'components/adminPage/Users'
 import Metrics from 'components/adminPage/Metrics'
+import Settings from 'components/adminPage/Settings'
 import Signin from 'components/adminPage/Signin'
 import { isAuthorized } from 'actions/users'
 
@@ -34,6 +35,7 @@ const routes = (
     <Route path='maintenances' component={Maintenances} onEnter={requireAuth} />
     <Route path='users' component={Users} onEnter={requireAuth} />
     <Route path='metrics' component={Metrics} onEnter={requireAuth} />
+    <Route path='settings' component={Settings} onEnter={requireAuth} />
     <Route path='signin' component={Signin} onEnter={guestOnly} />
   </Route>
 )

--- a/packages/frontend/src/components/adminPage/Settings/Settings.js
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.js
@@ -1,29 +1,29 @@
 import React, { PropTypes } from 'react'
 import classnames from 'classnames'
 import TextField from 'components/common/TextField'
-import Button from 'settings/common/Button'
-import ErrorMessage from 'settings/common/ErrorMessage'
+import Button from 'components/common/Button'
+import ErrorMessage from 'components/common/ErrorMessage'
 import classes from './Settings.scss'
 
 export default class Settings extends React.Component {
   static propTypes = {
     settings: PropTypes.shape({
-      adminPageURL: PropTypes.string.isRequired,
-      statusPageURL: PropTypes.string.isRequired,
-      serviceName: PropTypes.string.isRequired
+      adminPageURL: PropTypes.string,
+      statusPageURL: PropTypes.string,
+      serviceName: PropTypes.string
     }).isRequired,
     fetchSettings: PropTypes.func.isRequired,
     updateSettings: PropTypes.func.isRequired
   }
 
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
     this.state = {
       isFetching: false,
       message: '',
-      adminPageURL: this.props.settings.adminPageURL,
-      statusPageURL: this.props.settings.statusPageURL,
-      serviceName: this.props.settings.serviceName
+      adminPageURL: props.settings.adminPageURL,
+      statusPageURL: props.settings.statusPageURL,
+      serviceName: props.settings.serviceName
     }
   }
 
@@ -39,9 +39,17 @@ export default class Settings extends React.Component {
     this.props.fetchSettings(this.callbacks)
   }
 
+  componentWillReceiveProps (nextProps) {
+    this.setState({
+      adminPageURL: nextProps.settings.adminPageURL,
+      statusPageURL: nextProps.settings.statusPageURL,
+      serviceName: nextProps.settings.serviceName
+    })
+  }
+
   handleChangeValue = (key) => {
     return (value) => {
-      this.setState({key: value})
+      this.setState({[key]: value})
     }
   }
 
@@ -50,12 +58,27 @@ export default class Settings extends React.Component {
                               this.callbacks)
   }
 
+  renderItem = (key) => {
+    const text = key.charAt(0).toUpperCase() + key.slice(1)
+    return (
+      <ul key={key} className={classnames(classes.item, 'mdl-cell', 'mdl-cell--7-col', 'mdl-list')}>
+        <TextField label={text} text={this.state[key]} rows={1} onChange={this.handleChangeValue(key)} />
+      </ul>
+    )
+  }
+
   render () {
-    const settingItems = Object.keys(this.props.settings).map(key => {
-      return (
-        <TextField label={key} text={this.state.settings[key]} rows={1} onChange={this.handleChangeValue(key)} />
+    const settingKeys = ['serviceName', 'statusPageURL', 'adminPageURL']  // want to specify the order
+    const settingItems = settingKeys.map(this.renderItem)
+
+    let errMsg
+    if (this.state.message) {
+      errMsg = (
+        <div className='mdl-cell mdl-cell--12-col mdl-cell--middle'>
+          <ErrorMessage message={this.state.message} />
+        </div>
       )
-    })
+    }
 
     return (
       <div className={classnames(classes.layout, 'mdl-grid')}
@@ -63,14 +86,13 @@ export default class Settings extends React.Component {
         <div className='mdl-cell mdl-cell--12-col mdl-cell--middle'>
           <h4>Settings</h4>
         </div>
-        <div className='mdl-cell mdl-cell--12-col mdl-list'>
-          <ErrorMessage message={this.state.message} />
+        {errMsg}
+        {settingItems}
+        <div className='mdl-cell mdl-cell--6-col mdl-cell--middle' />
+        <div className='mdl-cell mdl-cell--1-col'>
+          <Button onClick={this.handleClickSaveButton} name='Save'
+            class='mdl-button--accent' disabled={this.state.isUpdating} />
         </div>
-        <ul className='mdl-cell mdl-cell--12-col mdl-list'>
-          {settingItems}
-        </ul>
-        <Button onClick={this.handleClickSaveButton} name='Save'
-          class='mdl-button--accent' disabled={this.state.isUpdating} />
       </div>
     )
   }

--- a/packages/frontend/src/components/adminPage/Settings/Settings.js
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.js
@@ -21,9 +21,9 @@ export default class Settings extends React.Component {
     this.state = {
       isFetching: false,
       message: '',
-      adminPageURL: props.settings.adminPageURL,
-      statusPageURL: props.settings.statusPageURL,
-      serviceName: props.settings.serviceName
+      adminPageURL: props.settings.adminPageURL || '',
+      statusPageURL: props.settings.statusPageURL || '',
+      serviceName: props.settings.serviceName || ''
     }
   }
 
@@ -70,6 +70,7 @@ export default class Settings extends React.Component {
   }
 
   render () {
+    // eslint-disable-next-line max-len
     const urlSettingInfo = 'Affects the links in email notifications, RSS feeds, and so on. It doesn\'t change your DNS setting.'
     const settings = [
       {key: 'serviceName'},

--- a/packages/frontend/src/components/adminPage/Settings/Settings.js
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.js
@@ -58,18 +58,25 @@ export default class Settings extends React.Component {
                               this.callbacks)
   }
 
-  renderItem = (key) => {
+  renderItem = (setting) => {
+    const { key, info } = setting
     const text = key.charAt(0).toUpperCase() + key.slice(1)
     return (
       <ul key={key} className={classnames(classes.item, 'mdl-cell', 'mdl-cell--7-col', 'mdl-list')}>
-        <TextField label={text} text={this.state[key]} rows={1} onChange={this.handleChangeValue(key)} />
+        <TextField label={text} text={this.state[key]} rows={1} onChange={this.handleChangeValue(key)}
+          information={info} />
       </ul>
     )
   }
 
   render () {
-    const settingKeys = ['serviceName', 'statusPageURL', 'adminPageURL']  // want to specify the order
-    const settingItems = settingKeys.map(this.renderItem)
+    const urlSettingInfo = 'Affects the links in email notifications, RSS feeds, and so on. It doesn\'t change your DNS setting.'
+    const settings = [
+      {key: 'serviceName'},
+      {key: 'statusPageURL', info: urlSettingInfo},
+      {key: 'adminPageURL', info: urlSettingInfo}
+    ]
+    const settingItems = settings.map(this.renderItem)
 
     let errMsg
     if (this.state.message) {

--- a/packages/frontend/src/components/adminPage/Settings/Settings.js
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.js
@@ -29,7 +29,7 @@ export default class Settings extends React.Component {
 
   callbacks = {
     onLoad: () => { this.setState({isUpdating: true}) },
-    onSuccess: () => { this.setState({isUpdating: false}) },
+    onSuccess: () => { this.setState({isUpdating: false, message: ''}) },
     onFailure: (msg) => {
       this.setState({isUpdating: false, message: msg})
     }

--- a/packages/frontend/src/components/adminPage/Settings/Settings.js
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.js
@@ -70,7 +70,7 @@ export default class Settings extends React.Component {
   }
 
   render () {
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line
     const urlSettingInfo = 'Affects the links in email notifications, RSS feeds, and so on. It doesn\'t change your DNS setting.'
     const settings = [
       {key: 'serviceName'},

--- a/packages/frontend/src/components/adminPage/Settings/Settings.js
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.js
@@ -1,0 +1,77 @@
+import React, { PropTypes } from 'react'
+import classnames from 'classnames'
+import TextField from 'components/common/TextField'
+import Button from 'settings/common/Button'
+import ErrorMessage from 'settings/common/ErrorMessage'
+import classes from './Settings.scss'
+
+export default class Settings extends React.Component {
+  static propTypes = {
+    settings: PropTypes.shape({
+      adminPageURL: PropTypes.string.isRequired,
+      statusPageURL: PropTypes.string.isRequired,
+      serviceName: PropTypes.string.isRequired
+    }).isRequired,
+    fetchSettings: PropTypes.func.isRequired,
+    updateSettings: PropTypes.func.isRequired
+  }
+
+  constructor () {
+    super()
+    this.state = {
+      isFetching: false,
+      message: '',
+      adminPageURL: this.props.settings.adminPageURL,
+      statusPageURL: this.props.settings.statusPageURL,
+      serviceName: this.props.settings.serviceName
+    }
+  }
+
+  callbacks = {
+    onLoad: () => { this.setState({isUpdating: true}) },
+    onSuccess: () => { this.setState({isUpdating: false}) },
+    onFailure: (msg) => {
+      this.setState({isUpdating: false, message: msg})
+    }
+  }
+
+  componentDidMount () {
+    this.props.fetchSettings(this.callbacks)
+  }
+
+  handleChangeValue = (key) => {
+    return (value) => {
+      this.setState({key: value})
+    }
+  }
+
+  handleClickSaveButton = () => {
+    this.props.updateSettings(this.state.serviceName, this.state.adminPageURL, this.state.statusPageURL,
+                              this.callbacks)
+  }
+
+  render () {
+    const settingItems = Object.keys(this.props.settings).map(key => {
+      return (
+        <TextField label={key} text={this.state.settings[key]} rows={1} onChange={this.handleChangeValue(key)} />
+      )
+    })
+
+    return (
+      <div className={classnames(classes.layout, 'mdl-grid')}
+        style={{ opacity: this.state.isFetching ? 0.5 : 1 }}>
+        <div className='mdl-cell mdl-cell--12-col mdl-cell--middle'>
+          <h4>Settings</h4>
+        </div>
+        <div className='mdl-cell mdl-cell--12-col mdl-list'>
+          <ErrorMessage message={this.state.message} />
+        </div>
+        <ul className='mdl-cell mdl-cell--12-col mdl-list'>
+          {settingItems}
+        </ul>
+        <Button onClick={this.handleClickSaveButton} name='Save'
+          class='mdl-button--accent' disabled={this.state.isUpdating} />
+      </div>
+    )
+  }
+}

--- a/packages/frontend/src/components/adminPage/Settings/Settings.scss
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.scss
@@ -1,0 +1,6 @@
+.layout {
+  padding-left: 40px;
+  padding-right: 40px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}

--- a/packages/frontend/src/components/adminPage/Settings/Settings.scss
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.scss
@@ -4,3 +4,11 @@
   padding-top: 10px;
   padding-bottom: 10px;
 }
+
+.item {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  color: rgba(0, 0, 0, .54);
+}

--- a/packages/frontend/src/components/adminPage/Settings/index.js
+++ b/packages/frontend/src/components/adminPage/Settings/index.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import { fetchSettings, updateSettings } from 'actions/settings'
+import Settings from './Settings'
+
+const mapStateToProps = (state) => {
+  return {
+    settings: state.settings.settings
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return bindActionCreators({fetchSettings, updateSettings}, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Settings)

--- a/packages/frontend/src/components/common/MetricsGraph/MetricsGraph.js
+++ b/packages/frontend/src/components/common/MetricsGraph/MetricsGraph.js
@@ -15,12 +15,17 @@ export default class MetricsGraph extends React.Component {
       unit: PropTypes.string.isRequired,
       data: PropTypes.object
     }),
+    settings: PropTypes.shape({
+      statusPageURL: PropTypes.string
+    }).isRequired,
     timeframe: PropTypes.oneOf(timeframes).isRequired,
     fetchData: PropTypes.func.isRequired
   }
 
   componentDidMount () {
-    this.fetchMetricData()
+    if (this.props.settings.statusPageURL) {
+      this.fetchMetricData()
+    }
 
     if (this.props.metric.data) {
       this.updateGraph()
@@ -28,7 +33,14 @@ export default class MetricsGraph extends React.Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
+    if (!prevProps.settings.statusPageURL && this.props.settings.statusPageURL) {
+      // On componentDidMount, url was unknown. So fetch the data now.
+      this.fetchMetricData()
+      return
+    }
+
     if (!this.props.metric.data) {
+      // now fetching...
       return
     }
 
@@ -47,7 +59,7 @@ export default class MetricsGraph extends React.Component {
     const currDate = new Date()
     currDate.setTime(currDate.getTime() + currDate.getTimezoneOffset() * 60 * 1000)  // UTC
     for (let i = 0; i < numDates + 1; i++) {
-      this.props.fetchData(this.props.metricID, currDate.getFullYear(),
+      this.props.fetchData(this.props.settings.statusPageURL, this.props.metricID, currDate.getFullYear(),
         currDate.getMonth() + 1, currDate.getDate())
       currDate.setDate(currDate.getDate() - 1)
     }

--- a/packages/frontend/src/components/common/MetricsGraph/index.js
+++ b/packages/frontend/src/components/common/MetricsGraph/index.js
@@ -17,8 +17,7 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 function mapDispatchToProps (dispatch, ownProps) {
-  const fetchData = fetchMetricsData.bind(null, ownProps.settings.StatusPageURL)
-  return bindActionCreators({fetchData}, dispatch)
+  return bindActionCreators({fetchData: fetchMetricsData}, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(MetricsGraph)

--- a/packages/frontend/src/components/common/MetricsGraph/index.js
+++ b/packages/frontend/src/components/common/MetricsGraph/index.js
@@ -11,12 +11,14 @@ const mapStateToProps = (state, ownProps) => {
     }
   })
   return {
-    metric: focusedMetric
+    metric: focusedMetric,
+    settings: state.settings.settings
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return bindActionCreators({fetchData: fetchMetricsData}, dispatch)
+function mapDispatchToProps (dispatch, ownProps) {
+  const fetchData = fetchMetricsData.bind(null, ownProps.settings.StatusPageURL)
+  return bindActionCreators({fetchData}, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(MetricsGraph)

--- a/packages/frontend/src/components/common/TextField/TextField.scss
+++ b/packages/frontend/src/components/common/TextField/TextField.scss
@@ -7,3 +7,18 @@
   color: #607D8B;
   font-size: 14px;
 }
+
+.icon {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.tooltip {
+  background-color: #777 !important;
+  padding: 3px 10px !important;
+  width: 25rem;
+}
+
+.tooltip::after {
+  border-right-color: #777 !important;
+}

--- a/packages/frontend/src/components/common/TextField/index.js
+++ b/packages/frontend/src/components/common/TextField/index.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import ReactDOM from 'react-dom'
 import classnames from 'classnames'
+import ReactTooltip from 'react-tooltip'
 import classes from './TextField.scss'
 
 const ENTER_KEY_CODE = 13
@@ -12,7 +13,8 @@ export default class TextField extends React.Component {
     label: PropTypes.string.isRequired,
     text: PropTypes.string,
     rows: PropTypes.number,
-    hideText: PropTypes.bool
+    hideText: PropTypes.bool,
+    information: PropTypes.string
   }
 
   componentDidMount () {
@@ -37,6 +39,16 @@ export default class TextField extends React.Component {
       textfieldType = 'password'
     }
 
+    let infoIcon, tooltip
+    if (this.props.information) {
+      infoIcon = (
+        <i className={classnames(classes.icon, 'material-icons')} data-tip={this.props.information}>info_outline</i>
+      )
+      tooltip = (
+        <ReactTooltip effect='solid' place='right' className={classes.tooltip} />
+      )
+    }
+
     let textfield
     if (!this.props.rows || this.props.rows === 1) {
       textfield = (<input className='mdl-textfield__input' type={textfieldType} id='textfield'
@@ -49,7 +61,8 @@ export default class TextField extends React.Component {
     return (
       <div className={classnames('mdl-textfield', 'mdl-js-textfield',
         classes.textfield)} ref='textfield'>
-        <label className={classes.label} htmlFor='textfield'>{this.props.label}</label>
+        <label className={classes.label} htmlFor='textfield'>{this.props.label}{infoIcon}</label>
+        {tooltip}
         {textfield}
       </div>
     )

--- a/packages/frontend/src/components/statusPage/Header/Header.js
+++ b/packages/frontend/src/components/statusPage/Header/Header.js
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react'
+
+export default class Header extends React.Component {
+  static propTypes = {
+    fetchSettings: PropTypes.func.isRequired
+  }
+
+  componentDidMount () {
+    this.props.fetchSettings()
+  }
+
+  render () {
+    return null
+  }
+}

--- a/packages/frontend/src/components/statusPage/Header/index.js
+++ b/packages/frontend/src/components/statusPage/Header/index.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import { fetchPublicSettings } from 'actions/settings'
+import Header from './Header'
+
+const mapStateToProps = (state) => {
+  return {
+    settings: state.settings.settings
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return bindActionCreators({fetchSettings: fetchPublicSettings}, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Header)

--- a/packages/frontend/src/components/statusPage/History/History.js
+++ b/packages/frontend/src/components/statusPage/History/History.js
@@ -18,11 +18,10 @@ export default class History extends React.Component {
       updatedAt: PropTypes.string.isRequired
     }).isRequired).isRequired,
     settings: PropTypes.shape({
-      serviceName: PropTypes.string.isRequired
+      serviceName: PropTypes.string
     }).isRequired,
     fetchIncidents: PropTypes.func.isRequired,
-    fetchMaintenances: PropTypes.func.isRequired,
-    fetchPublicSettings: PropTypes.func.isRequired
+    fetchMaintenances: PropTypes.func.isRequired
   }
 
   constructor () {
@@ -43,7 +42,6 @@ export default class History extends React.Component {
   componentDidMount () {
     this.props.fetchIncidents(this.fetchCallbacks)
     this.props.fetchMaintenances(this.fetchCallbacks)
-    this.props.fetchPublicSettings()
   }
 
   renderEventItems = (month, events) => {

--- a/packages/frontend/src/components/statusPage/History/History.js
+++ b/packages/frontend/src/components/statusPage/History/History.js
@@ -5,7 +5,6 @@ import Title from 'components/statusPage/Title'
 import IncidentItem from 'components/statusPage/IncidentItem'
 import MaintenanceItem from 'components/statusPage/MaintenanceItem'
 import { getDateTimeFormat } from 'utils/datetime'
-import { serviceName } from 'utils/settings'
 import classes from './History.scss'
 
 export default class History extends React.Component {
@@ -18,8 +17,12 @@ export default class History extends React.Component {
       maintenanceID: PropTypes.string.isRequired,
       updatedAt: PropTypes.string.isRequired
     }).isRequired).isRequired,
+    settings: PropTypes.shape({
+      serviceName: PropTypes.string.isRequired
+    }).isRequired,
     fetchIncidents: PropTypes.func.isRequired,
-    fetchMaintenances: PropTypes.func.isRequired
+    fetchMaintenances: PropTypes.func.isRequired,
+    fetchPublicSettings: PropTypes.func.isRequired
   }
 
   constructor () {
@@ -40,6 +43,7 @@ export default class History extends React.Component {
   componentDidMount () {
     this.props.fetchIncidents(this.fetchCallbacks)
     this.props.fetchMaintenances(this.fetchCallbacks)
+    this.props.fetchPublicSettings()
   }
 
   renderEventItems = (month, events) => {
@@ -85,13 +89,13 @@ export default class History extends React.Component {
   }
 
   render () {
-    const { incidents, maintenances } = this.props
+    const { incidents, maintenances, settings } = this.props
     const events = incidents.concat(maintenances)
     const eventsByMonth = this.renderEventsByMonth(events)
 
     return (<div className={classnames(classes.layout, 'mdl-grid')}
       style={{ opacity: this.state.isFetching ? 0.5 : 1 }}>
-      <Title service_name={serviceName} />
+      <Title service_name={settings.serviceName} />
       <div className='mdl-cell mdl-cell--12-col'>
         <h4>Incident History</h4>
       </div>

--- a/packages/frontend/src/components/statusPage/History/index.js
+++ b/packages/frontend/src/components/statusPage/History/index.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { fetchIncidents } from 'actions/incidents'
 import { fetchMaintenances } from 'actions/maintenances'
-import { fetchPublicSettings } from 'actions/settings'
 import History from './History'
 
 const mapStateToProps = (state) => {
@@ -14,7 +13,7 @@ const mapStateToProps = (state) => {
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({fetchIncidents, fetchMaintenances, fetchPublicSettings}, dispatch)
+  return bindActionCreators({fetchIncidents, fetchMaintenances}, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(History)

--- a/packages/frontend/src/components/statusPage/History/index.js
+++ b/packages/frontend/src/components/statusPage/History/index.js
@@ -2,17 +2,19 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { fetchIncidents } from 'actions/incidents'
 import { fetchMaintenances } from 'actions/maintenances'
+import { fetchPublicSettings } from 'actions/settings'
 import History from './History'
 
 const mapStateToProps = (state) => {
   return {
     incidents: state.incidents.incidents,
-    maintenances: state.maintenances.maintenances
+    maintenances: state.maintenances.maintenances,
+    settings: state.settings.settings
   }
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({fetchIncidents, fetchMaintenances}, dispatch)
+  return bindActionCreators({fetchIncidents, fetchMaintenances, fetchPublicSettings}, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(History)

--- a/packages/frontend/src/components/statusPage/Incident/Incident.js
+++ b/packages/frontend/src/components/statusPage/Incident/Incident.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react'
 import classnames from 'classnames'
 import ModestLink from 'components/common/ModestLink'
 import IncidentItem from 'components/statusPage/IncidentItem'
-import { serviceName } from 'utils/settings'
 import classes from './Incident.scss'
 
 export default class Incident extends React.Component {
@@ -13,6 +12,9 @@ export default class Incident extends React.Component {
       name: PropTypes.string.isRequired,
       status: PropTypes.string
     }),
+    settings: PropTypes.shape({
+      serviceName: PropTypes.string.isRequired
+    }).isRequired,
     fetchIncidents: PropTypes.func.isRequired
   }
 
@@ -23,12 +25,12 @@ export default class Incident extends React.Component {
   }
 
   render () {
-    const { incidentID } = this.props
+    const { incidentID, settings } = this.props
 
     return (
       <div className={classnames(classes.layout, 'mdl-grid')}>
         <div className='mdl-cell mdl-cell--12-col'>
-          <h4>Incident Report for {serviceName}</h4>
+          <h4>Incident Report for {settings.serviceName}</h4>
         </div>
         <div className='mdl-cell mdl-cell--12-col mdl-list'>
           {(this.props.incident) ? <IncidentItem key={incidentID} incidentID={incidentID} autoloadDetail /> : ''}

--- a/packages/frontend/src/components/statusPage/Incident/Incident.js
+++ b/packages/frontend/src/components/statusPage/Incident/Incident.js
@@ -13,7 +13,7 @@ export default class Incident extends React.Component {
       status: PropTypes.string
     }),
     settings: PropTypes.shape({
-      serviceName: PropTypes.string.isRequired
+      serviceName: PropTypes.string
     }).isRequired,
     fetchIncidents: PropTypes.func.isRequired
   }

--- a/packages/frontend/src/components/statusPage/Incident/index.js
+++ b/packages/frontend/src/components/statusPage/Incident/index.js
@@ -12,7 +12,8 @@ const mapStateToProps = (state, ownProps) => {
   })
   return {
     incidentID: ownProps.params.id,
-    incident: focusedIncident
+    incident: focusedIncident,
+    settings: state.settings.settings
   }
 }
 

--- a/packages/frontend/src/components/statusPage/Maintenance/Maintenance.js
+++ b/packages/frontend/src/components/statusPage/Maintenance/Maintenance.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react'
 import classnames from 'classnames'
 import ModestLink from 'components/common/ModestLink'
 import MaintenanceItem from 'components/statusPage/MaintenanceItem'
-import { serviceName } from 'utils/settings'
 import classes from './Maintenance.scss'
 
 export default class Maintenance extends React.Component {
@@ -16,6 +15,9 @@ export default class Maintenance extends React.Component {
       startAt: PropTypes.string.isRequired,
       endAt: PropTypes.string.isRequired
     }),
+    settings: PropTypes.shape({
+      serviceName: PropTypes.string.isRequired
+    }).isRequired,
     fetchMaintenances: PropTypes.func.isRequired
   }
 
@@ -26,12 +28,12 @@ export default class Maintenance extends React.Component {
   }
 
   render () {
-    const { maintenanceID: id } = this.props
+    const { maintenanceID: id, settings } = this.props
 
     return (
       <div className={classnames(classes.layout, 'mdl-grid')}>
         <div className='mdl-cell mdl-cell--12-col'>
-          <h4>Scheduled Maintenance Report for {serviceName}</h4>
+          <h4>Scheduled Maintenance Report for {settings.serviceName}</h4>
         </div>
         <div className='mdl-cell mdl-cell--12-col mdl-list'>
           {(this.props.maintenance) ? <MaintenanceItem key={id} maintenanceID={id} autoloadDetail /> : ''}

--- a/packages/frontend/src/components/statusPage/Maintenance/Maintenance.js
+++ b/packages/frontend/src/components/statusPage/Maintenance/Maintenance.js
@@ -16,7 +16,7 @@ export default class Maintenance extends React.Component {
       endAt: PropTypes.string.isRequired
     }),
     settings: PropTypes.shape({
-      serviceName: PropTypes.string.isRequired
+      serviceName: PropTypes.string
     }).isRequired,
     fetchMaintenances: PropTypes.func.isRequired
   }

--- a/packages/frontend/src/components/statusPage/Maintenance/index.js
+++ b/packages/frontend/src/components/statusPage/Maintenance/index.js
@@ -12,7 +12,8 @@ const mapStateToProps = (state, ownProps) => {
   })
   return {
     maintenanceID: ownProps.params.id,
-    maintenance: focusedMaintenance
+    maintenance: focusedMaintenance,
+    settings: state.settings.settings
   }
 }
 

--- a/packages/frontend/src/components/statusPage/StatusPageLayout/index.js
+++ b/packages/frontend/src/components/statusPage/StatusPageLayout/index.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import classnames from 'classnames'
+import Header from 'components/statusPage/Header'
 import classes from './StatusPageLayout.scss'
 
 export const StatusPageLayout = ({ children }) => (
   <div className={classnames(classes.root, 'mdl-layout')}>
+    <Header />
     <main className={classnames(classes.main, 'mdl-layout__content')}>
       {children}
     </main>

--- a/packages/frontend/src/components/statusPage/Statuses/Statuses.js
+++ b/packages/frontend/src/components/statusPage/Statuses/Statuses.js
@@ -7,7 +7,6 @@ import Title from 'components/statusPage/Title'
 import Components from 'components/statusPage/Components'
 import Incidents from 'components/statusPage/Incidents'
 import ScheduledMaintenances from 'components/statusPage/ScheduledMaintenances'
-import { serviceName } from 'utils/settings'
 import { timeframes } from 'utils/status'
 import classes from './Statuses.scss'
 
@@ -16,7 +15,11 @@ export default class Statuses extends React.Component {
     metrics: PropTypes.arrayOf(PropTypes.shape({
       metricID: PropTypes.string.isRequired
     }).isRequired).isRequired,
-    fetchPublicMetrics: PropTypes.func.isRequired
+    settings: PropTypes.shape({
+      serviceName: PropTypes.string.isRequired
+    }).isRequired,
+    fetchPublicMetrics: PropTypes.func.isRequired,
+    fetchPublicSettings: PropTypes.func.isRequired
   }
 
   constructor () {
@@ -38,6 +41,7 @@ export default class Statuses extends React.Component {
 
   componentDidMount () {
     this.props.fetchPublicMetrics(this.fetchCallbacks)
+    this.props.fetchPublicSettings()
   }
 
   clickHandler = (timeframe) => {
@@ -65,7 +69,7 @@ export default class Statuses extends React.Component {
   }
 
   render () {
-    const { metrics } = this.props
+    const { metrics, settings } = this.props
     const components = (<Components classNames='mdl-cell mdl-cell--12-col mdl-list' />)
     const timeframeSelector = this.renderTimeframeSelector()
     const incidents = (<Incidents classNames='mdl-cell mdl-cell--12-col mdl-list' />)
@@ -95,7 +99,7 @@ export default class Statuses extends React.Component {
 
     return (<div className={classnames(classes.layout, 'mdl-grid')}
       style={{ opacity: this.state.isFetching ? 0.5 : 1 }}>
-      <Title service_name={serviceName} />
+      <Title service_name={settings.serviceName} />
       {components}
       {maintenances}
       {metricsTitle}

--- a/packages/frontend/src/components/statusPage/Statuses/Statuses.js
+++ b/packages/frontend/src/components/statusPage/Statuses/Statuses.js
@@ -16,10 +16,9 @@ export default class Statuses extends React.Component {
       metricID: PropTypes.string.isRequired
     }).isRequired).isRequired,
     settings: PropTypes.shape({
-      serviceName: PropTypes.string.isRequired
+      serviceName: PropTypes.string
     }).isRequired,
-    fetchPublicMetrics: PropTypes.func.isRequired,
-    fetchPublicSettings: PropTypes.func.isRequired
+    fetchPublicMetrics: PropTypes.func.isRequired
   }
 
   constructor () {
@@ -41,7 +40,6 @@ export default class Statuses extends React.Component {
 
   componentDidMount () {
     this.props.fetchPublicMetrics(this.fetchCallbacks)
-    this.props.fetchPublicSettings()
   }
 
   clickHandler = (timeframe) => {

--- a/packages/frontend/src/components/statusPage/Statuses/index.js
+++ b/packages/frontend/src/components/statusPage/Statuses/index.js
@@ -2,17 +2,19 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { fetchComponents } from 'actions/components'
 import { fetchPublicMetrics } from 'actions/metrics'
+import { fetchPublicSettings } from 'actions/settings'
 import Statuses from './Statuses'
 
 const mapStateToProps = (state) => {
   return {
     components: state.components.components,
-    metrics: state.metrics.metrics
+    metrics: state.metrics.metrics,
+    settings: state.settings.settings
   }
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({fetchComponents, fetchPublicMetrics}, dispatch)
+  return bindActionCreators({fetchComponents, fetchPublicMetrics, fetchPublicSettings}, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Statuses)

--- a/packages/frontend/src/components/statusPage/Statuses/index.js
+++ b/packages/frontend/src/components/statusPage/Statuses/index.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { fetchComponents } from 'actions/components'
 import { fetchPublicMetrics } from 'actions/metrics'
-import { fetchPublicSettings } from 'actions/settings'
 import Statuses from './Statuses'
 
 const mapStateToProps = (state) => {
@@ -14,7 +13,7 @@ const mapStateToProps = (state) => {
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({fetchComponents, fetchPublicMetrics, fetchPublicSettings}, dispatch)
+  return bindActionCreators({fetchComponents, fetchPublicMetrics}, dispatch)
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Statuses)

--- a/packages/frontend/src/components/statusPage/Title/index.js
+++ b/packages/frontend/src/components/statusPage/Title/index.js
@@ -9,6 +9,6 @@ export const Title = (props) => (
 )
 
 Title.propTypes = {
-  service_name: PropTypes.string.isRequired
+  service_name: PropTypes.string
 }
 export default Title

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -17,8 +17,6 @@
         if (x.readyState === 4 && x.status === 200) {
           j = JSON.parse(x.responseText);
           __LAMBSTATUS_API_URL__ = j.InvocationURL;
-          __LAMBSTATUS_STATUS_PAGE_URL__ = j.StatusPageURL;
-          __LAMBSTATUS_SERVICE_NAME__ = j.ServiceName;
           __LAMBSTATUS_USER_POOL_ID__ = j.UserPoolID;
           __LAMBSTATUS_CLIENT_ID__ = j.ClientID;
         }

--- a/packages/frontend/src/reducers/index.js
+++ b/packages/frontend/src/reducers/index.js
@@ -5,12 +5,14 @@ import incidentReducer from 'reducers/incidents'
 import maintenanceReducer from 'reducers/maintenances'
 import metricsReducer from 'reducers/metrics'
 import userReducer from 'reducers/users'
+import settingsReducer from 'reducers/settings'
 
 const rootReducer = combineReducers({
   components: componentReducer,
   incidents: incidentReducer,
   maintenances: maintenanceReducer,
   user: userReducer,
+  settings: settingsReducer,
   metrics: metricsReducer,
   router
 })

--- a/packages/frontend/src/reducers/settings.js
+++ b/packages/frontend/src/reducers/settings.js
@@ -18,8 +18,7 @@ const ACTION_HANDLERS = {
 }
 
 export default function settingsReducer (state = {
-  settings: [],
-  externalSettings: {}
+  settings: {}
 }, action) {
   const handler = ACTION_HANDLERS[action.type]
   return handler ? handler(state, action) : state

--- a/packages/frontend/src/reducers/settings.js
+++ b/packages/frontend/src/reducers/settings.js
@@ -1,0 +1,26 @@
+import { LIST_SETTINGS, EDIT_SETTINGS } from 'actions/settings'
+
+function listSettingsHandler (state = { }, action) {
+  return Object.assign({}, state, {
+    settings: JSON.parse(action.settings)
+  })
+}
+
+function editSettingsHandler (state = { }, action) {
+  return Object.assign({}, state, {
+    settings: JSON.parse(action.settings)
+  })
+}
+
+const ACTION_HANDLERS = {
+  [LIST_SETTINGS]: listSettingsHandler,
+  [EDIT_SETTINGS]: editSettingsHandler
+}
+
+export default function settingsReducer (state = {
+  settings: [],
+  externalSettings: {}
+}, action) {
+  const handler = ACTION_HANDLERS[action.type]
+  return handler ? handler(state, action) : state
+}

--- a/packages/frontend/src/status-page.js
+++ b/packages/frontend/src/status-page.js
@@ -96,8 +96,6 @@ const timer = setInterval(() => {
     clearInterval(timer)
 
     settings.apiURL = __LAMBSTATUS_API_URL__
-    settings.serviceName = __LAMBSTATUS_SERVICE_NAME__
-    settings.statusPageURL = __LAMBSTATUS_STATUS_PAGE_URL__
     settings.userPoolId = __LAMBSTATUS_USER_POOL_ID__
     settings.clientId = __LAMBSTATUS_CLIENT_ID__
     render(routes)

--- a/packages/frontend/src/utils/settings.js
+++ b/packages/frontend/src/utils/settings.js
@@ -1,6 +1,4 @@
 // These values are set when the settings json is loaded.
 export let apiURL
-export let serviceName
-export let statusPageURL
 export let userPoolId
 export let clientId

--- a/packages/frontend/tests/test-bundler.js
+++ b/packages/frontend/tests/test-bundler.js
@@ -10,8 +10,6 @@ global.sinon = sinon
 global.assert = assert
 global.console.error = () => {}
 settings.apiURL = '/'
-settings.serviceName = ''
-settings.statusPageURL = ''
 settings.userPoolId = 'ap-northeast-1_XXXXXXXXX'
 settings.clientId = 'test'
 

--- a/packages/lambda/bin/setup-apex.js
+++ b/packages/lambda/bin/setup-apex.js
@@ -65,7 +65,9 @@ const cognitoHandleFunctionRoleArn = getArn(awsResourceIDs, 'CognitoHandleFuncti
 createFunctionJSON(cognitoHandleFunctionRoleArn, 30, 128, [
   buildDir + '/functions/CognitoCreateUser',
   buildDir + '/functions/CognitoCreateUserPool',
-  buildDir + '/functions/CognitoCreateUserPoolClient'
+  buildDir + '/functions/CognitoCreateUserPoolClient',
+  buildDir + '/functions/DBCreateItems',
+  buildDir + '/functions/PatchSettings'
 ])
 const apiGatewayHandleFunctionRoleArn = getArn(awsResourceIDs, 'APIGatewayHandleFunctionRoleArn')
 createFunctionJSON(apiGatewayHandleFunctionRoleArn, 30, 128, [

--- a/packages/lambda/config/webpack.config.es6.js
+++ b/packages/lambda/config/webpack.config.es6.js
@@ -124,6 +124,10 @@ export default {
     PatchSettings: [
       'babel-polyfill',
       './src/api/patchSettings/index.js'
+    ],
+    DBCreateItems: [
+      'babel-polyfill',
+      './src/api/dbCreateItems/index.js'
     ]
   },
   output: {

--- a/packages/lambda/config/webpack.config.es6.js
+++ b/packages/lambda/config/webpack.config.es6.js
@@ -112,6 +112,18 @@ export default {
     APIGatewayDeploy: [
       'babel-polyfill',
       './src/api/apiGatewayDeploy/index.js'
+    ],
+    GetPublicSettings: [
+      'babel-polyfill',
+      './src/api/getPublicSettings/index.js'
+    ],
+    GetSettings: [
+      'babel-polyfill',
+      './src/api/getSettings/index.js'
+    ],
+    PatchSettings: [
+      'babel-polyfill',
+      './src/api/patchSettings/index.js'
     ]
   },
   output: {

--- a/packages/lambda/src/api/apiGatewayDeploy/index.js
+++ b/packages/lambda/src/api/apiGatewayDeploy/index.js
@@ -2,7 +2,7 @@ import response from 'cfn-response'
 import APIGateway from 'aws/apiGateway'
 
 export async function handle (event, context, callback) {
-  if (event.RequestType === 'Delete') {
+  if (event.RequestType === 'Create' || event.RequestType === 'Delete') {
     response.send(event, context, response.SUCCESS)
     return
   }

--- a/packages/lambda/src/api/cognitoCreateUser/index.js
+++ b/packages/lambda/src/api/cognitoCreateUser/index.js
@@ -2,20 +2,8 @@ import response from 'cfn-response'
 import Cognito from 'aws/cognito'
 
 export async function handle (event, context, callback) {
-  if (event.RequestType === 'Delete') {
-    // UserPool will be deleted too, so do nothing here.
+  if (event.RequestType === 'Update' || event.RequestType === 'Delete') {
     response.send(event, context, response.SUCCESS)
-    return
-  }
-
-  if (event.RequestType === 'Update') {
-    if (event.ResourceProperties.UserName !== event.OldResourceProperties.UserName ||
-      event.ResourceProperties.Email !== event.OldResourceProperties.Email) {
-      console.log('can\'t update parameters of user')
-      response.send(event, context, response.FAILED)
-    } else {
-      response.send(event, context, response.SUCCESS)
-    }
     return
   }
 

--- a/packages/lambda/src/api/cognitoCreateUserPool/index.js
+++ b/packages/lambda/src/api/cognitoCreateUserPool/index.js
@@ -24,15 +24,8 @@ export async function handle (event, context, callback) {
   }
 
   if (event.RequestType === 'Update') {
-    const oldProps = event.OldResourceProperties
-    if (poolName !== oldProps.PoolName || snsCallerArn !== oldProps.SnsCallerArn ||
-      adminPageURL !== oldProps.AdminPageURL) {
-      console.log(`can't update parameters of user pool`)
-      response.send(event, context, response.FAILED)
-    } else {
-      const poolID = event.PhysicalResourceId
-      response.send(event, context, response.SUCCESS, {UserPoolID: poolID})
-    }
+    const poolID = event.PhysicalResourceId
+    response.send(event, context, response.SUCCESS, {UserPoolID: poolID})
     return
   }
 

--- a/packages/lambda/src/api/cognitoCreateUserPool/index.js
+++ b/packages/lambda/src/api/cognitoCreateUserPool/index.js
@@ -1,11 +1,11 @@
 import response from 'cfn-response'
 import Cognito from 'aws/cognito'
+import { Settings } from 'model/settings'
 
 export async function handle (event, context, callback) {
   const {
     Region: region,
     PoolName: poolName,
-    ServiceName: serviceName,
     AdminPageURL: adminPageURL,
     SnsCallerArn: snsCallerArn
   } = event.ResourceProperties
@@ -24,11 +24,10 @@ export async function handle (event, context, callback) {
   }
 
   if (event.RequestType === 'Update') {
-    if (poolName !== event.OldResourceProperties.poolName ||
-      snsCallerArn !== event.OldResourceProperties.SnsCallerArn ||
-      serviceName !== event.OldResourceProperties.ServiceName ||
-      adminPageURL !== event.OldResourceProperties.AdminPageURL) {
-      console.log('can\'t update parameters of user pool')
+    const oldProps = event.OldResourceProperties
+    if (poolName !== oldProps.PoolName || snsCallerArn !== oldProps.SnsCallerArn ||
+      adminPageURL !== oldProps.AdminPageURL) {
+      console.log(`can't update parameters of user pool`)
       response.send(event, context, response.FAILED)
     } else {
       const poolID = event.PhysicalResourceId
@@ -38,6 +37,9 @@ export async function handle (event, context, callback) {
   }
 
   try {
+    const settings = new Settings()
+    const serviceName = await settings.getServiceName()
+
     const userPool = await new Cognito().createUserPool(region, poolName, serviceName, adminPageURL, snsCallerArn)
     const poolID = userPool.UserPool.Id
     response.send(event, context, response.SUCCESS, {UserPoolID: poolID}, poolID)

--- a/packages/lambda/src/api/cognitoCreateUserPoolClient/index.js
+++ b/packages/lambda/src/api/cognitoCreateUserPoolClient/index.js
@@ -2,21 +2,10 @@ import response from 'cfn-response'
 import Cognito from 'aws/cognito'
 
 export async function handle (event, context, callback) {
-  if (event.RequestType === 'Delete') {
+  if (event.RequestType === 'Update' || event.RequestType === 'Delete') {
     // UserPool will be deleted too, so do nothing here.
     const clientID = event.PhysicalResourceId
     response.send(event, context, response.SUCCESS, {UserPoolClientID: clientID})
-    return
-  }
-
-  if (event.RequestType === 'Update') {
-    if (event.ResourceProperties.ClientName !== event.OldResourceProperties.ClientName) {
-      console.log('can\'t update parameters of user pool client')
-      response.send(event, context, response.FAILED)
-    } else {
-      const clientID = event.PhysicalResourceId
-      response.send(event, context, response.SUCCESS, {UserPoolClientID: clientID})
-    }
     return
   }
 

--- a/packages/lambda/src/api/dbCreateItems/index.js
+++ b/packages/lambda/src/api/dbCreateItems/index.js
@@ -1,26 +1,28 @@
+import response from 'cfn-response'
 import { Settings } from 'model/settings'
 
 export async function handle (event, context, callback) {
+  if (event.RequestType === 'Update' || event.RequestType === 'Delete') {
+    response.send(event, context, response.SUCCESS)
+    return
+  }
+
   const {
-    serviceName,
-    adminPageURL,
-    statusPageURL
-  } = event.body
+    AdminPageURL: adminPageURL,
+    StatusPageURL: statusPageURL
+  } = event.ResourceProperties
   try {
     const settings = new Settings()
-    if (serviceName) {
-      await settings.setServiceName(serviceName)
-    }
     if (adminPageURL) {
       await settings.setAdminPageURL(adminPageURL)
     }
     if (statusPageURL) {
       await settings.setStatusPageURL(statusPageURL)
     }
-    callback(null, JSON.stringify({serviceName, adminPageURL, statusPageURL}))
+    response.send(event, context, response.SUCCESS)
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)
-    callback('Error: failed to set settings')
+    response.send(event, context, response.FAILED)
   }
 }

--- a/packages/lambda/src/api/dbCreateItems/index.js
+++ b/packages/lambda/src/api/dbCreateItems/index.js
@@ -9,7 +9,8 @@ export async function handle (event, context, callback) {
 
   const {
     AdminPageURL: adminPageURL,
-    StatusPageURL: statusPageURL
+    StatusPageURL: statusPageURL,
+    CognitoPoolID: cognitoPoolID
   } = event.ResourceProperties
   try {
     const settings = new Settings()
@@ -18,6 +19,9 @@ export async function handle (event, context, callback) {
     }
     if (statusPageURL) {
       await settings.setStatusPageURL(statusPageURL)
+    }
+    if (cognitoPoolID) {
+      await settings.setCognitoPoolID(cognitoPoolID)
     }
     response.send(event, context, response.SUCCESS)
   } catch (error) {

--- a/packages/lambda/src/api/getPublicSettings/index.js
+++ b/packages/lambda/src/api/getPublicSettings/index.js
@@ -2,9 +2,9 @@ import { Settings } from 'model/settings'
 
 export async function handle (event, context, callback) {
   try {
-    const settings = await new Settings()
-    const serviceName = settings.getServiceName()
-    const statusPageURL = settings.getStatusPageURL()
+    const settings = new Settings()
+    const serviceName = await settings.getServiceName()
+    const statusPageURL = await settings.getStatusPageURL()
     callback(null, JSON.stringify({serviceName, statusPageURL}))
   } catch (error) {
     console.log(error.message)

--- a/packages/lambda/src/api/getPublicSettings/index.js
+++ b/packages/lambda/src/api/getPublicSettings/index.js
@@ -1,0 +1,14 @@
+import { Settings } from 'model/settings'
+
+export async function handle (event, context, callback) {
+  try {
+    const settings = await new Settings()
+    const serviceName = settings.getServiceName()
+    const statusPageURL = settings.getStatusPageURL()
+    callback(null, JSON.stringify({serviceName, statusPageURL}))
+  } catch (error) {
+    console.log(error.message)
+    console.log(error.stack)
+    callback('Error: failed to get status page settings')
+  }
+}

--- a/packages/lambda/src/api/getSettings/index.js
+++ b/packages/lambda/src/api/getSettings/index.js
@@ -1,0 +1,15 @@
+import { Settings } from 'model/settings'
+
+export async function handle (event, context, callback) {
+  try {
+    const settings = await new Settings()
+    const serviceName = settings.getServiceName()
+    const adminPageURL = settings.getAdminPageURL()
+    const statusPageURL = settings.getStatusPageURL()
+    callback(null, JSON.stringify({serviceName, adminPageURL, statusPageURL}))
+  } catch (error) {
+    console.log(error.message)
+    console.log(error.stack)
+    callback('Error: failed to get settings')
+  }
+}

--- a/packages/lambda/src/api/getSettings/index.js
+++ b/packages/lambda/src/api/getSettings/index.js
@@ -2,10 +2,10 @@ import { Settings } from 'model/settings'
 
 export async function handle (event, context, callback) {
   try {
-    const settings = await new Settings()
-    const serviceName = settings.getServiceName()
-    const adminPageURL = settings.getAdminPageURL()
-    const statusPageURL = settings.getStatusPageURL()
+    const settings = new Settings()
+    const serviceName = await settings.getServiceName()
+    const adminPageURL = await settings.getAdminPageURL()
+    const statusPageURL = await settings.getStatusPageURL()
     callback(null, JSON.stringify({serviceName, adminPageURL, statusPageURL}))
   } catch (error) {
     console.log(error.message)

--- a/packages/lambda/src/api/patchSettings/index.js
+++ b/packages/lambda/src/api/patchSettings/index.js
@@ -1,0 +1,26 @@
+import { Settings } from 'model/settings'
+
+export async function handle (event, context, callback) {
+  const {
+    serviceName,
+    adminPageURL,
+    statusPageURL
+  } = event.body
+  try {
+    const settings = await new Settings()
+    if (serviceName) {
+      settings.setServiceName(serviceName)
+    }
+    if (adminPageURL) {
+      settings.setAdminPageURL(adminPageURL)
+    }
+    if (statusPageURL) {
+      settings.setStatusPageURL(statusPageURL)
+    }
+    callback(null, JSON.stringify({serviceName, adminPageURL, statusPageURL}))
+  } catch (error) {
+    console.log(error.message)
+    console.log(error.stack)
+    callback('Error: failed to set settings')
+  }
+}

--- a/packages/lambda/src/api/patchSettings/index.js
+++ b/packages/lambda/src/api/patchSettings/index.js
@@ -8,13 +8,13 @@ export async function handle (event, context, callback) {
   } = event.body
   try {
     const settings = new Settings()
-    if (serviceName) {
+    if (serviceName !== undefined) {
       await settings.setServiceName(serviceName)
     }
-    if (adminPageURL) {
+    if (adminPageURL !== undefined) {
       await settings.setAdminPageURL(adminPageURL)
     }
-    if (statusPageURL) {
+    if (statusPageURL !== undefined) {
       await settings.setStatusPageURL(statusPageURL)
     }
     callback(null, JSON.stringify({serviceName, adminPageURL, statusPageURL}))

--- a/packages/lambda/src/api/patchSettings/index.js
+++ b/packages/lambda/src/api/patchSettings/index.js
@@ -21,6 +21,15 @@ export async function handle (event, context, callback) {
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)
-    callback('Error: failed to set settings')
+    switch (error.name) {
+      case 'ValidationError':
+        callback('Error: ' + error.message)
+        break
+      case 'NotFoundError':
+        callback('Error: an item not found')
+        break
+      default:
+        callback('Error: failed to set settings')
+    }
   }
 }

--- a/packages/lambda/src/db/settings.js
+++ b/packages/lambda/src/db/settings.js
@@ -2,7 +2,7 @@ import AWS from 'aws-sdk'
 import VError from 'verror'
 import { NotFoundError } from 'utils/errors'
 import { SettingsTable } from 'utils/const'
-import { buildUpdateExpression, fillInsufficientProps } from './utils'
+import { buildUpdateExpression } from './utils'
 
 export default class SettingsStore {
   constructor () {

--- a/packages/lambda/src/db/settings.js
+++ b/packages/lambda/src/db/settings.js
@@ -2,7 +2,7 @@ import AWS from 'aws-sdk'
 import VError from 'verror'
 import { NotFoundError } from 'utils/errors'
 import { SettingsTable } from 'utils/const'
-import { buildUpdateExpression } from './utils'
+import { buildUpdateExpression, fillInsufficientProps } from './utils'
 
 export default class SettingsStore {
   constructor () {
@@ -54,6 +54,11 @@ export default class SettingsStore {
       this.awsDynamoDb.update(params, (err, data) => {
         if (err) {
           return reject(new VError(err, 'DynamoDB'))
+        }
+        if (data.Attributes === undefined) {
+          // No item matching the given key
+          resolve('')
+          return
         }
         resolve(data.Attributes.value)
       })

--- a/packages/lambda/src/db/settings.js
+++ b/packages/lambda/src/db/settings.js
@@ -14,11 +14,15 @@ export default class SettingsStore {
     return new Promise((resolve, reject) => {
       const params = {
         TableName: SettingsTable,
-        KeyConditionExpression: 'key = :hkey',
+        KeyConditionExpression: '#k = :hkey',
+        ExpressionAttributeNames: {
+          '#k': 'key',
+          '#v': 'value'
+        },
         ExpressionAttributeValues: {
           ':hkey': key
         },
-        ProjectionExpression: 'value'
+        ProjectionExpression: '#v'
       }
       this.awsDynamoDb.query(params, (err, queryResult) => {
         if (err) {

--- a/packages/lambda/src/db/settings.js
+++ b/packages/lambda/src/db/settings.js
@@ -35,12 +35,12 @@ export default class SettingsStore {
           return reject(new Error('matched too many items'))
         }
 
-        resolve(queryResult.Items[0][key])
+        resolve(queryResult.Items[0].value)
       })
     })
   }
 
-  set (key, value) {
+  update (key, value) {
     const [updateExp, attrNames, attrValues] = buildUpdateExpression({ value })
     return new Promise((resolve, reject) => {
       const params = {
@@ -55,7 +55,7 @@ export default class SettingsStore {
         if (err) {
           return reject(new VError(err, 'DynamoDB'))
         }
-        resolve(data.Attributes)
+        resolve(data.Attributes.value)
       })
     })
   }

--- a/packages/lambda/src/db/settings.js
+++ b/packages/lambda/src/db/settings.js
@@ -1,0 +1,58 @@
+import AWS from 'aws-sdk'
+import VError from 'verror'
+import { NotFoundError } from 'utils/errors'
+import { SettingsTable } from 'utils/const'
+import { buildUpdateExpression } from './utils'
+
+export default class SettingsStore {
+  constructor () {
+    const { AWS_REGION: region } = process.env
+    this.awsDynamoDb = new AWS.DynamoDB.DocumentClient({ region })
+  }
+
+  get (key) {
+    return new Promise((resolve, reject) => {
+      const params = {
+        TableName: SettingsTable,
+        KeyConditionExpression: 'key = :hkey',
+        ExpressionAttributeValues: {
+          ':hkey': key
+        },
+        ProjectionExpression: 'value'
+      }
+      this.awsDynamoDb.query(params, (err, queryResult) => {
+        if (err) {
+          return reject(new VError(err, 'DynamoDB'))
+        }
+
+        if (queryResult.Items.length === 0) {
+          return reject(new NotFoundError('no matched item'))
+        } else if (queryResult.Items.length !== 1) {
+          return reject(new Error('matched too many items'))
+        }
+
+        resolve(queryResult.Items[0][key])
+      })
+    })
+  }
+
+  set (key, value) {
+    const [updateExp, attrNames, attrValues] = buildUpdateExpression({ value })
+    return new Promise((resolve, reject) => {
+      const params = {
+        Key: { key },
+        UpdateExpression: updateExp,
+        ExpressionAttributeNames: attrNames,
+        ExpressionAttributeValues: attrValues,
+        TableName: SettingsTable,
+        ReturnValues: 'ALL_NEW'
+      }
+      this.awsDynamoDb.update(params, (err, data) => {
+        if (err) {
+          return reject(new VError(err, 'DynamoDB'))
+        }
+        resolve(data.Attributes)
+      })
+    })
+  }
+}

--- a/packages/lambda/src/db/utils.js
+++ b/packages/lambda/src/db/utils.js
@@ -2,7 +2,7 @@ export const buildUpdateExpression = (values) => {
   const setExps = []
   const removeExps = []
   const attrNames = {}
-  const attrValues = {}
+  let attrValues = {}
   Object.keys(values).forEach((key) => {
     const value = values[key]
     const attrName = `#${key}`
@@ -22,6 +22,10 @@ export const buildUpdateExpression = (values) => {
   }
   if (removeExps.length !== 0) {
     exps += `REMOVE ${removeExps.join(', ')} `
+  }
+  if (Object.keys(attrValues).length === 0) {
+    // empty attrValues fails at the validation
+    attrValues = undefined
   }
   return [exps, attrNames, attrValues]
 }

--- a/packages/lambda/src/model/settings.js
+++ b/packages/lambda/src/model/settings.js
@@ -1,0 +1,49 @@
+import SettingsStore from 'db/settings'
+import { ValidationError } from 'utils/errors'
+
+const settingsKeyServiceName = 'ServiceName'
+const settingsKeyStatusPageURL = 'StatusPageURL'
+const settingsKeyAdminPageURL = 'AdminPageURL'
+
+// InvocationURL, UserPoolID, ClientID are bootstrap set. Do not store here.
+
+export class Settings {
+  constructor () {
+    this.store = new SettingsStore()
+  }
+
+  validateURL (url) {
+    // eslint-disable-next-line no-useless-escape, max-len
+    return url.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g) !== null
+  }
+
+  async getServiceName () {
+    return await this.store.get(settingsKeyServiceName)
+  }
+
+  async setServiceName (value) {
+    return await this.store.set(settingsKeyServiceName, value)
+  }
+
+  async getStatusPageURL () {
+    return await this.store.get(settingsKeyStatusPageURL)
+  }
+
+  async setStatusPageURL (value) {
+    if (!this.validateURL(value)) {
+      throw new ValidationError('invalid url')
+    }
+    return await this.store.set(settingsKeyStatusPageURL, value)
+  }
+
+  async getAdminPageURL () {
+    return await this.store.get(settingsKeyAdminPageURL)
+  }
+
+  async setAdminPageURL (value) {
+    if (!this.validateURL(value)) {
+      throw new ValidationError('invalid url')
+    }
+    return await this.store.set(settingsKeyAdminPageURL, value)
+  }
+}

--- a/packages/lambda/src/model/settings.js
+++ b/packages/lambda/src/model/settings.js
@@ -21,7 +21,7 @@ export class Settings {
     try {
       return await this.store.get(settingsKeyServiceName)
     } catch (err) {
-      if (err instanceof NotFoundError) {
+      if (err.name === NotFoundError.name) {
         return ''
       }
       throw err
@@ -29,14 +29,14 @@ export class Settings {
   }
 
   async setServiceName (value) {
-    return await this.store.set(settingsKeyServiceName, value)
+    return await this.store.update(settingsKeyServiceName, value)
   }
 
   async getStatusPageURL () {
     try {
       return await this.store.get(settingsKeyStatusPageURL)
     } catch (err) {
-      if (err instanceof NotFoundError) {
+      if (err.name === NotFoundError.name) {
         return ''
       }
       throw err
@@ -47,14 +47,14 @@ export class Settings {
     if (!this.validateURL(value)) {
       throw new ValidationError('invalid url')
     }
-    return await this.store.set(settingsKeyStatusPageURL, value)
+    return await this.store.update(settingsKeyStatusPageURL, value)
   }
 
   async getAdminPageURL () {
     try {
       return await this.store.get(settingsKeyAdminPageURL)
     } catch (err) {
-      if (err instanceof NotFoundError) {
+      if (err.name === NotFoundError.name) {
         return ''
       }
       throw err
@@ -65,6 +65,6 @@ export class Settings {
     if (!this.validateURL(value)) {
       throw new ValidationError('invalid url')
     }
-    return await this.store.set(settingsKeyAdminPageURL, value)
+    return await this.store.update(settingsKeyAdminPageURL, value)
   }
 }

--- a/packages/lambda/src/model/settings.js
+++ b/packages/lambda/src/model/settings.js
@@ -1,5 +1,5 @@
 import SettingsStore from 'db/settings'
-import { ValidationError } from 'utils/errors'
+import { ValidationError, NotFoundError } from 'utils/errors'
 
 const settingsKeyServiceName = 'ServiceName'
 const settingsKeyStatusPageURL = 'StatusPageURL'
@@ -18,7 +18,14 @@ export class Settings {
   }
 
   async getServiceName () {
-    return await this.store.get(settingsKeyServiceName)
+    try {
+      return await this.store.get(settingsKeyServiceName)
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        return ''
+      }
+      throw err
+    }
   }
 
   async setServiceName (value) {
@@ -26,7 +33,14 @@ export class Settings {
   }
 
   async getStatusPageURL () {
-    return await this.store.get(settingsKeyStatusPageURL)
+    try {
+      return await this.store.get(settingsKeyStatusPageURL)
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        return ''
+      }
+      throw err
+    }
   }
 
   async setStatusPageURL (value) {
@@ -37,7 +51,14 @@ export class Settings {
   }
 
   async getAdminPageURL () {
-    return await this.store.get(settingsKeyAdminPageURL)
+    try {
+      return await this.store.get(settingsKeyAdminPageURL)
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        return ''
+      }
+      throw err
+    }
   }
 
   async setAdminPageURL (value) {

--- a/packages/lambda/src/utils/const.js
+++ b/packages/lambda/src/utils/const.js
@@ -6,6 +6,7 @@ export const MetricsTable = `${stackName}-MetricsTable`
 export const MetricsDataTable = `${stackName}-MetricsDataTable`
 export const MaintenanceTable = `${stackName}-MaintenanceTable`
 export const MaintenanceUpdateTable = `${stackName}-MaintenanceUpdateTable`
+export const SettingsTable = `${stackName}-SettingsTable`
 
 export const componentStatuses = ['Operational', 'Under Maintenance', 'Degraded Performance', 'Partial Outage',
   'Major Outage']

--- a/packages/lambda/test/db/settings.js
+++ b/packages/lambda/test/db/settings.js
@@ -1,0 +1,93 @@
+import assert from 'assert'
+import AWS from 'aws-sdk-mock'
+import SettingsStore from 'db/settings'
+
+describe('SettingsStore', () => {
+  describe('get', () => {
+    afterEach(() => {
+      AWS.restore('DynamoDB.DocumentClient')
+    })
+
+    it('should return the value associated with the given key', async () => {
+      const key = 'testkey'
+      const value = 'testvalue'
+      AWS.mock('DynamoDB.DocumentClient', 'query', (params, callback) => {
+        callback(null, {Items: [{key, value}]})
+      })
+      const setting = await new SettingsStore().get(key)
+      assert(value === setting)
+    })
+
+    it('should throw NotFoundError if no associated key exists', async () => {
+      AWS.mock('DynamoDB.DocumentClient', 'query', (params, callback) => {
+        callback(null, {Items: []})
+      })
+
+      let error
+      try {
+        await new SettingsStore().get('testkey')
+      } catch (e) {
+        error = e
+      }
+      assert(error.name.match(/NotFoundError/))
+    })
+
+    it('should throw Error if multiple items found', async () => {
+      AWS.mock('DynamoDB.DocumentClient', 'query', (params, callback) => {
+        callback(null, {Items: [{}, {}]})
+      })
+
+      let error
+      try {
+        await new SettingsStore().get('testkey')
+      } catch (e) {
+        error = e
+      }
+      assert(error.name.match(/Error/))
+    })
+
+    it('should call reject on error', async () => {
+      AWS.mock('DynamoDB.DocumentClient', 'query', (params, callback) => {
+        callback('Error')
+      })
+
+      let error
+      try {
+        await new SettingsStore().get('testkey')
+      } catch (e) {
+        error = e
+      }
+      assert(error.message.match(/Error/))
+    })
+  })
+
+  describe('update', () => {
+    afterEach(() => {
+      AWS.restore('DynamoDB.DocumentClient')
+    })
+
+    it('should update the component', async () => {
+      const key = 'testkey'
+      const value = 'testvalue'
+      AWS.mock('DynamoDB.DocumentClient', 'update', (params, callback) => {
+        callback(null, {Attributes: {key, value}})
+      })
+      const setting = await new SettingsStore().update(key, value)
+      assert(value === setting)
+    })
+
+    it('should return error on exception thrown', async () => {
+      AWS.mock('DynamoDB.DocumentClient', 'update', (params, callback) => {
+        callback('Error')
+      })
+
+      let error
+      try {
+        await new SettingsStore().update('', '')
+      } catch (e) {
+        error = e
+      }
+      assert(error.message.match(/Error/))
+    })
+  })
+})

--- a/packages/lambda/test/model/settings.js
+++ b/packages/lambda/test/model/settings.js
@@ -1,0 +1,81 @@
+import assert from 'assert'
+import sinon from 'sinon'
+import { Settings } from 'model/settings'
+import SettingsStore from 'db/settings'
+import { NotFoundError } from 'utils/errors'
+
+describe('Settings', () => {
+  describe('vaildateURL', () => {
+    it('should return true if the URL is valid', async () => {
+      const settings = new Settings()
+      const urls = ['https://example.com', 'http://example.com', 'example.com', 'https://example.com/test']
+      urls.forEach(url => {
+        assert(settings.validateURL(url))
+      })
+    })
+
+    it('should return false if the URL is invalid', async () => {
+      const settings = new Settings()
+      const urls = ['https://', '', 'https://example']
+      urls.forEach(url => {
+        assert(!settings.validateURL(url))
+      })
+    })
+  })
+
+  describe('getServiceName', () => {
+    afterEach(() => {
+      SettingsStore.prototype.get.restore()
+    })
+
+    it('should return one component', async () => {
+      const expected = 'value'
+      sinon.stub(SettingsStore.prototype, 'get').returns(expected)
+
+      const actual = await new Settings().getServiceName()
+      assert(actual === expected)
+    })
+
+    it('should return empty string when matched no component', async () => {
+      sinon.stub(SettingsStore.prototype, 'get').throws(new NotFoundError())
+      const actual = await new Settings().getServiceName()
+      assert(actual === '')
+    })
+
+    it('should throw error when error returned', async () => {
+      sinon.stub(SettingsStore.prototype, 'get').throws(new Error())
+      let error
+      try {
+        await new Settings().getServiceName()
+      } catch (e) {
+        error = e
+      }
+      assert(error.name === 'Error')
+    })
+  })
+
+  describe('setServiceName', () => {
+    afterEach(() => {
+      SettingsStore.prototype.update.restore()
+    })
+
+    it('should return one component', async () => {
+      const expected = 'value'
+      sinon.stub(SettingsStore.prototype, 'update').returns(expected)
+
+      const actual = await new Settings().setServiceName(expected)
+      assert(actual === expected)
+    })
+
+    it('should throw error when error returned', async () => {
+      sinon.stub(SettingsStore.prototype, 'update').throws(new Error())
+      let error
+      try {
+        await new Settings().setServiceName('')
+      } catch (e) {
+        error = e
+      }
+      assert(error.name === 'Error')
+    })
+  })
+})

--- a/packages/lambda/test/model/settings.js
+++ b/packages/lambda/test/model/settings.js
@@ -59,12 +59,16 @@ describe('Settings', () => {
       SettingsStore.prototype.update.restore()
     })
 
-    it('should return one component', async () => {
+    it('should update the service name and user pool', async () => {
       const expected = 'value'
-      sinon.stub(SettingsStore.prototype, 'update').returns(expected)
+      const updateStub = sinon.stub(SettingsStore.prototype, 'update')
+      updateStub.returns(expected)
+      const updateUserPoolStub = sinon.stub(Settings.prototype, 'updateUserPool')
 
-      const actual = await new Settings().setServiceName(expected)
-      assert(actual === expected)
+      await new Settings().setServiceName(expected)
+      assert(updateStub.called)
+      assert(updateUserPoolStub.called)
+      Settings.prototype.updateUserPool.restore()
     })
 
     it('should throw error when error returned', async () => {


### PR DESCRIPTION
To make the status page looks official one, its domain should be something like `status.your.service.domain` rather than `XXX.cloufront.net`. This PR enables us to change the domain setting. The value is used by the links in email notifications, RSS feeds, and so on. It is admin's responsibility to change the DNS setting, though.


