### PR TITLE
Fetch CloudWatch metrics from other regions

### DIFF
--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -1942,6 +1942,7 @@ Resources:
       RequestParameters:
         method.request.querystring.type: false
         method.request.querystring.cursor: false
+        method.request.querystring.filters: false
       Integration:
         Type: "AWS"
         IntegrationHttpMethod: "POST"
@@ -1953,7 +1954,11 @@ Resources:
                 - "Arn"
         RequestTemplates:
           application/json: !Sub |-
-            {"type":"$input.params('type')","cursor":"$input.params('cursor')"}
+            {
+              "type":"$input.params('type')",
+              "cursor":"$input.params('cursor')",
+              "filters":"$util.escapeJavaScript($input.params('filters'))"
+            }
         IntegrationResponses:
           - StatusCode: "200"
             ResponseParameters:

--- a/packages/frontend/src/actions/metrics.js
+++ b/packages/frontend/src/actions/metrics.js
@@ -104,7 +104,6 @@ export const fetchExternalMetrics = (metricsType, filters = {}, callbacks = {}) 
           headers: await buildHeaders()
         })
         metrics = metrics.concat(json.metrics)
-        dispatch(listExternalMetrics(metricsType, filters, metrics))
 
         if (json.nextCursor) {
           nextCursor = json.nextCursor
@@ -112,6 +111,7 @@ export const fetchExternalMetrics = (metricsType, filters = {}, callbacks = {}) 
           break
         }
       }
+      dispatch(listExternalMetrics(metricsType, filters, metrics))
       if (onSuccess && typeof onSuccess === 'function') onSuccess()
     } catch (error) {
       console.error(error.message)

--- a/packages/frontend/src/actions/metrics.js
+++ b/packages/frontend/src/actions/metrics.js
@@ -86,7 +86,6 @@ export const fetchExternalMetrics = (metricsType, callbacks = {}) => {
   return async dispatch => {
     try {
       const encodedMetricsType = encodeURIComponent(metricsType)
-      const cursorPattern = /"nextCursor":"([^"]*)"/
       let nextCursor
       while (true) {
         let queryParam = `type=${encodedMetricsType}`
@@ -96,11 +95,10 @@ export const fetchExternalMetrics = (metricsType, callbacks = {}) => {
         const json = await sendRequest(`${apiURL}external-metrics?${queryParam}`, {
           headers: await buildHeaders()
         }, callbacks)
-        dispatch(listExternalMetrics(metricsType, json))
+        dispatch(listExternalMetrics(metricsType, json.metrics))
 
-        const matched = json.match(cursorPattern)
-        if (matched && matched.length === 2) {
-          nextCursor = matched[1]
+        if (json.nextCursor) {
+          nextCursor = json.nextCursor
         } else {
           break
         }

--- a/packages/frontend/src/actions/metrics.js
+++ b/packages/frontend/src/actions/metrics.js
@@ -85,7 +85,10 @@ export const fetchPublicMetrics = (callbacks = {}) => {
 
 export const fetchExternalMetrics = (metricsType, filters = {}, callbacks = {}) => {
   return async dispatch => {
+    const { onLoad, onSuccess, onFailure } = callbacks
     try {
+      if (onLoad && typeof onLoad === 'function') onLoad()
+
       let queryParam = `type=${encodeURIComponent(metricsType)}`
       if (filters) {
         queryParam += `${queryParam}&filters=${encodeURIComponent(JSON.stringify(filters))}`
@@ -99,7 +102,7 @@ export const fetchExternalMetrics = (metricsType, filters = {}, callbacks = {}) 
         }
         const json = await sendRequest(url, {
           headers: await buildHeaders()
-        }, callbacks)
+        })
         metrics = metrics.concat(json.metrics)
         dispatch(listExternalMetrics(metricsType, filters, metrics))
 
@@ -109,9 +112,11 @@ export const fetchExternalMetrics = (metricsType, filters = {}, callbacks = {}) 
           break
         }
       }
+      if (onSuccess && typeof onSuccess === 'function') onSuccess()
     } catch (error) {
       console.error(error.message)
       console.error(error.stack)
+      if (onFailure && typeof onFailure === 'function') onFailure(error.message)
     }
   }
 }

--- a/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.js
+++ b/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.js
@@ -28,14 +28,14 @@ export default class CloudWatchMetricsSelector extends React.Component {
 
     this.regionNames = regions.map(r => r.name)
 
-    const namespace = props.props ? props.props.Namespace : ''
-    const metric = props.props ? this.buildMetricExpression(props.props) : ''
     const region = (props.props && props.props.Region) ? props.props.Region : this.region
     const regionName = regions.find(r => r.id === region).name
+    const namespace = props.props ? props.props.Namespace : ''
+    const metric = props.props ? this.buildMetricExpression(props.props) : ''
     this.state = {
+      regionName,
       namespace,
       metric,
-      regionName,
       isFetching: false
     }
   }
@@ -63,14 +63,14 @@ export default class CloudWatchMetricsSelector extends React.Component {
   }
 
   handleChangeRegion = (value) => {
-    this.setState({regionName: value})
+    this.setState({regionName: value, namespace: '', metric: ''})
 
     const regionID = regions.find(r => r.name === value).id
     this.props.fetchExternalMetrics('CloudWatch', {region: regionID}, this.callbacks)
   }
 
   handleChangeNamespace = (value) => {
-    this.setState({namespace: value})
+    this.setState({namespace: value, metric: ''})
   }
 
   handleChangeMetric = (value) => {
@@ -113,7 +113,7 @@ export default class CloudWatchMetricsSelector extends React.Component {
   render () {
     let namespaces = ['']
     let metrics = ['']
-    if (this.props.metrics) {
+    if (!this.needFetching()) {
       const namespaceSet = new Set()
       this.props.metrics.forEach((metric) => {
         namespaceSet.add(metric.Namespace)
@@ -156,7 +156,7 @@ export default class CloudWatchMetricsSelector extends React.Component {
           </div>
         </label>
         <div id='namespace' className={classes['dropdown-list']}>
-          <DropdownList onChange={this.handleChangeNamespace}
+          <DropdownList disabled={this.state.isFetching} onChange={this.handleChangeNamespace}
             list={namespaces} initialValue={this.state.namespace} />
         </div>
 
@@ -167,7 +167,7 @@ export default class CloudWatchMetricsSelector extends React.Component {
           </div>
         </label>
         <div id='name' className={classes['dropdown-list']}>
-          <DropdownList onChange={this.handleChangeMetric}
+          <DropdownList disabled={this.state.isFetching} onChange={this.handleChangeMetric}
             list={metrics} initialValue={this.state.metric} />
         </div>
 

--- a/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.js
+++ b/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.js
@@ -53,7 +53,7 @@ export default class CloudWatchMetricsSelector extends React.Component {
   }
 
   handleChangeRegion = (value) => {
-    this.setState({region: value})
+    this.setState({regionName: value})
 
     const regionID = regions.find(r => r.name === value).id
     this.props.fetchExternalMetrics('CloudWatch', {region: regionID})

--- a/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.js
+++ b/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.js
@@ -145,7 +145,7 @@ export default class CloudWatchMetricsSelector extends React.Component {
             data-tip data-for='cloudWatchInfo'>info_outline</i>
         </label>
         <div id='region' className={classes['dropdown-list']}>
-          <DropdownList onChange={this.handleChangeRegion}
+          <DropdownList disabled={this.state.isFetching} onChange={this.handleChangeRegion}
             list={this.regionNames} initialValue={this.state.regionName} />
         </div>
 

--- a/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.js
+++ b/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react'
 import ReactTooltip from 'react-tooltip'
 import classnames from 'classnames'
 import DropdownList from 'components/common/DropdownList'
+import Spinner from 'components/common/Spinner'
 import { apiURL } from 'utils/settings'
 import { regions } from 'utils/status'
 import classes from './CloudWatchMetricsSelector.scss'
@@ -34,14 +35,23 @@ export default class CloudWatchMetricsSelector extends React.Component {
     this.state = {
       namespace,
       metric,
-      regionName
+      regionName,
+      isFetching: false
+    }
+  }
+
+  callbacks = {
+    onLoad: () => { this.setState({isFetching: true}) },
+    onSuccess: () => { this.setState({isFetching: false}) },
+    onFailure: () => {
+      this.setState({isFetching: false})
     }
   }
 
   componentDidMount () {
     if (this.needFetching()) {
       const regionID = regions.find(r => r.name === this.state.regionName).id
-      this.props.fetchExternalMetrics('CloudWatch', {region: regionID})
+      this.props.fetchExternalMetrics('CloudWatch', {region: regionID}, this.callbacks)
     }
   }
 
@@ -56,7 +66,7 @@ export default class CloudWatchMetricsSelector extends React.Component {
     this.setState({regionName: value})
 
     const regionID = regions.find(r => r.name === value).id
-    this.props.fetchExternalMetrics('CloudWatch', {region: regionID})
+    this.props.fetchExternalMetrics('CloudWatch', {region: regionID}, this.callbacks)
   }
 
   handleChangeNamespace = (value) => {
@@ -122,6 +132,10 @@ export default class CloudWatchMetricsSelector extends React.Component {
     }
 
     const linkToMetricsPage = `https://${this.region}.console.aws.amazon.com/cloudwatch/home?region=${this.region}#metricsV2:`
+    let spinner
+    if (this.state.isFetching) {
+      spinner = <Spinner enable class={classes['spinner']} />
+    }
 
     return (
       <div>
@@ -136,7 +150,10 @@ export default class CloudWatchMetricsSelector extends React.Component {
         </div>
 
         <label className={classes.label} htmlFor='namespace'>
-          CloudWatch Namespace
+          <div className={classes['spinner-box']}>
+            CloudWatch Namespace
+            {spinner}
+          </div>
         </label>
         <div id='namespace' className={classes['dropdown-list']}>
           <DropdownList onChange={this.handleChangeNamespace}
@@ -144,7 +161,10 @@ export default class CloudWatchMetricsSelector extends React.Component {
         </div>
 
         <label className={classes.label} htmlFor='name'>
-          CloudWatch MetricName & Dimensions
+          <div className={classes['spinner-box']}>
+            CloudWatch MetricName & Dimensions
+            {spinner}
+          </div>
         </label>
         <div id='name' className={classes['dropdown-list']}>
           <DropdownList onChange={this.handleChangeMetric}

--- a/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.scss
+++ b/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/CloudWatchMetricsSelector.scss
@@ -27,3 +27,11 @@
   font-size: 12px;
   font-weight: 700;
 }
+
+.spinner-box {
+  display: flex;
+}
+
+.spinner {
+  margin: 0 0.25rem;
+}

--- a/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/index.js
+++ b/packages/frontend/src/components/adminPage/CloudWatchMetricsSelector/index.js
@@ -4,9 +4,12 @@ import { fetchExternalMetrics } from 'actions/metrics'
 import CloudWatchMetricsSelector from './CloudWatchMetricsSelector'
 
 const mapStateToProps = (state) => {
-  return {
-    metrics: state.metrics.externalMetrics.CloudWatch
+  let filters, metrics
+  if (state.metrics.externalMetrics.CloudWatch) {
+    filters = state.metrics.externalMetrics.CloudWatch.filters
+    metrics = state.metrics.externalMetrics.CloudWatch.metrics
   }
+  return { metrics, filters }
 }
 
 function mapDispatchToProps (dispatch) {

--- a/packages/frontend/src/components/common/DropdownList/index.js
+++ b/packages/frontend/src/components/common/DropdownList/index.js
@@ -7,7 +7,8 @@ export default class DropdownList extends React.Component {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     list: PropTypes.array.isRequired,
-    initialValue: PropTypes.string.isRequired
+    initialValue: PropTypes.string.isRequired,
+    disabled: PropTypes.string
   }
 
   constructor (props) {
@@ -29,8 +30,10 @@ export default class DropdownList extends React.Component {
       return (<option key={elem}>{elem}</option>)
     })
     return (
-      <span className={classnames('mdl-textfield', 'mdl-js-textfield', classes.dropdown)} ref='dropdown'>
-        <select className='mdl-textfield__input' onChange={this.handleChange} value={this.props.initialValue}>
+      <span ref='dropdown' className={classnames('mdl-textfield', 'mdl-js-textfield', classes.dropdown,
+            (this.props.disabled ? 'is-disabled' : ''))}>
+        <select className='mdl-textfield__input' onChange={this.handleChange} value={this.props.initialValue}
+          disabled={this.props.disabled}>
           {statusDOMs}
         </select>
       </span>

--- a/packages/frontend/src/components/common/DropdownList/index.js
+++ b/packages/frontend/src/components/common/DropdownList/index.js
@@ -8,7 +8,7 @@ export default class DropdownList extends React.Component {
     onChange: PropTypes.func.isRequired,
     list: PropTypes.array.isRequired,
     initialValue: PropTypes.string.isRequired,
-    disabled: PropTypes.string
+    disabled: PropTypes.bool
   }
 
   constructor (props) {

--- a/packages/frontend/src/components/common/Spinner/Spinner.scss
+++ b/packages/frontend/src/components/common/Spinner/Spinner.scss
@@ -1,0 +1,134 @@
+.sk-fading-circle {
+  width: 18px;
+  height: 18px;
+  position: relative;
+}
+
+.sk-fading-circle .sk-circle {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.sk-fading-circle .sk-circle:before {
+  content: '';
+  display: block;
+  margin: 0 auto;
+  width: 15%;
+  height: 15%;
+  background-color: #333;
+  border-radius: 100%;
+  -webkit-animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
+          animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
+}
+.sk-fading-circle .sk-circle2 {
+  -webkit-transform: rotate(30deg);
+      -ms-transform: rotate(30deg);
+          transform: rotate(30deg);
+}
+.sk-fading-circle .sk-circle3 {
+  -webkit-transform: rotate(60deg);
+      -ms-transform: rotate(60deg);
+          transform: rotate(60deg);
+}
+.sk-fading-circle .sk-circle4 {
+  -webkit-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+          transform: rotate(90deg);
+}
+.sk-fading-circle .sk-circle5 {
+  -webkit-transform: rotate(120deg);
+      -ms-transform: rotate(120deg);
+          transform: rotate(120deg);
+}
+.sk-fading-circle .sk-circle6 {
+  -webkit-transform: rotate(150deg);
+      -ms-transform: rotate(150deg);
+          transform: rotate(150deg);
+}
+.sk-fading-circle .sk-circle7 {
+  -webkit-transform: rotate(180deg);
+      -ms-transform: rotate(180deg);
+          transform: rotate(180deg);
+}
+.sk-fading-circle .sk-circle8 {
+  -webkit-transform: rotate(210deg);
+      -ms-transform: rotate(210deg);
+          transform: rotate(210deg);
+}
+.sk-fading-circle .sk-circle9 {
+  -webkit-transform: rotate(240deg);
+      -ms-transform: rotate(240deg);
+          transform: rotate(240deg);
+}
+.sk-fading-circle .sk-circle10 {
+  -webkit-transform: rotate(270deg);
+      -ms-transform: rotate(270deg);
+          transform: rotate(270deg);
+}
+.sk-fading-circle .sk-circle11 {
+  -webkit-transform: rotate(300deg);
+      -ms-transform: rotate(300deg);
+          transform: rotate(300deg); 
+}
+.sk-fading-circle .sk-circle12 {
+  -webkit-transform: rotate(330deg);
+      -ms-transform: rotate(330deg);
+          transform: rotate(330deg); 
+}
+.sk-fading-circle .sk-circle2:before {
+  -webkit-animation-delay: -1.1s;
+          animation-delay: -1.1s; 
+}
+.sk-fading-circle .sk-circle3:before {
+  -webkit-animation-delay: -1s;
+          animation-delay: -1s; 
+}
+.sk-fading-circle .sk-circle4:before {
+  -webkit-animation-delay: -0.9s;
+          animation-delay: -0.9s; 
+}
+.sk-fading-circle .sk-circle5:before {
+  -webkit-animation-delay: -0.8s;
+          animation-delay: -0.8s; 
+}
+.sk-fading-circle .sk-circle6:before {
+  -webkit-animation-delay: -0.7s;
+          animation-delay: -0.7s; 
+}
+.sk-fading-circle .sk-circle7:before {
+  -webkit-animation-delay: -0.6s;
+          animation-delay: -0.6s; 
+}
+.sk-fading-circle .sk-circle8:before {
+  -webkit-animation-delay: -0.5s;
+          animation-delay: -0.5s; 
+}
+.sk-fading-circle .sk-circle9:before {
+  -webkit-animation-delay: -0.4s;
+          animation-delay: -0.4s;
+}
+.sk-fading-circle .sk-circle10:before {
+  -webkit-animation-delay: -0.3s;
+          animation-delay: -0.3s;
+}
+.sk-fading-circle .sk-circle11:before {
+  -webkit-animation-delay: -0.2s;
+          animation-delay: -0.2s;
+}
+.sk-fading-circle .sk-circle12:before {
+  -webkit-animation-delay: -0.1s;
+          animation-delay: -0.1s;
+}
+
+@-webkit-keyframes sk-circleFadeDelay {
+  0%, 39%, 100% { opacity: 0; }
+  40% { opacity: 1; }
+}
+
+@keyframes sk-circleFadeDelay {
+  0%, 39%, 100% { opacity: 0; }
+  40% { opacity: 1; } 
+}

--- a/packages/frontend/src/components/common/Spinner/index.js
+++ b/packages/frontend/src/components/common/Spinner/index.js
@@ -1,0 +1,34 @@
+import React, { PropTypes } from 'react'
+import classnames from 'classnames'
+import classes from './Spinner.scss'
+
+// based on SpinKit http://tobiasahlin.com/spinkit/
+export default class Spinner extends React.Component {
+  static propTypes = {
+    class: PropTypes.string,
+    enable: PropTypes.bool
+  }
+
+  render () {
+    if (!this.props.enable) {
+      return null
+    }
+
+    return (
+      <div className={classnames(this.props.class, classes['sk-fading-circle'])}>
+        <div className={classnames(classes['sk-circle1'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle2'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle3'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle4'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle5'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle6'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle7'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle8'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle9'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle10'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle11'], classes['sk-circle'])} />
+        <div className={classnames(classes['sk-circle12'], classes['sk-circle'])} />
+      </div>
+    )
+  }
+}

--- a/packages/frontend/src/reducers/components.js
+++ b/packages/frontend/src/reducers/components.js
@@ -2,7 +2,7 @@ import { LIST_COMPONENTS, ADD_COMPONENT, EDIT_COMPONENT, REMOVE_COMPONENT } from
 
 function listComponentsHandler (state = { }, action) {
   return Object.assign({}, state, {
-    components: JSON.parse(action.components)
+    components: action.components
   })
 }
 
@@ -10,13 +10,13 @@ function addComponentHandler (state = { }, action) {
   return Object.assign({}, state, {
     components: [
       ...state.components,
-      JSON.parse(action.component)
+      action.component
     ]
   })
 }
 
 function editComponentHandler (state = { }, action) {
-  let editedComponent = JSON.parse(action.component)
+  let editedComponent = action.component
 
   const newComponents = state.components.map((component) => {
     if (component.componentID === editedComponent.componentID) {

--- a/packages/frontend/src/reducers/incidents.js
+++ b/packages/frontend/src/reducers/incidents.js
@@ -2,7 +2,7 @@ import { LIST_INCIDENTS, LIST_INCIDENT_UPDATES, ADD_INCIDENT, EDIT_INCIDENT,
   REMOVE_INCIDENT } from 'actions/incidents'
 
 function listIncidentsHandler (state = { }, action) {
-  const incidents = JSON.parse(action.incidents)
+  const incidents = action.incidents
   incidents.sort((a, b) => {
     return a.updatedAt < b.updatedAt
   })
@@ -13,7 +13,7 @@ function listIncidentsHandler (state = { }, action) {
 }
 
 function listIncidentUpdatesHandler (state = { }, action) {
-  const incidentUpdates = JSON.parse(action.incidentUpdates)
+  const incidentUpdates = action.incidentUpdates
   incidentUpdates.sort((a, b) => {
     return a.updatedAt < b.updatedAt
   })
@@ -35,7 +35,7 @@ function listIncidentUpdatesHandler (state = { }, action) {
 function addIncidentHandler (state = { }, action) {
   const {
     incident
-  } = JSON.parse(action.response)
+  } = action.response
 
   return Object.assign({}, state, {
     incidents: [
@@ -48,7 +48,7 @@ function addIncidentHandler (state = { }, action) {
 function editIncidentHandler (state = { }, action) {
   const {
     incident: updatedIncident
-  } = JSON.parse(action.response)
+  } = action.response
 
   const newIncidents = state.incidents.map((incident) => {
     if (incident.incidentID === updatedIncident.incidentID) {

--- a/packages/frontend/src/reducers/maintenances.js
+++ b/packages/frontend/src/reducers/maintenances.js
@@ -2,7 +2,7 @@ import { LIST_MAINTENANCES, LIST_MAINTENANCE_UPDATES, ADD_MAINTENANCE, EDIT_MAIN
   REMOVE_MAINTENANCE } from 'actions/maintenances'
 
 function listMaintenancesHandler (state = { }, action) {
-  const maintenances = JSON.parse(action.maintenances)
+  const maintenances = action.maintenances
   maintenances.sort((a, b) => {
     return a.updatedAt < b.updatedAt
   })
@@ -13,7 +13,7 @@ function listMaintenancesHandler (state = { }, action) {
 }
 
 function listMaintenanceUpdatesHandler (state = { }, action) {
-  const maintenanceUpdates = JSON.parse(action.maintenanceUpdates)
+  const maintenanceUpdates = action.maintenanceUpdates
   maintenanceUpdates.sort((a, b) => {
     return a.updatedAt < b.updatedAt
   })
@@ -35,7 +35,7 @@ function listMaintenanceUpdatesHandler (state = { }, action) {
 function addMaintenanceHandler (state = { }, action) {
   const {
     maintenance
-  } = JSON.parse(action.response)
+  } = action.response
 
   return Object.assign({}, state, {
     maintenances: [
@@ -48,7 +48,7 @@ function addMaintenanceHandler (state = { }, action) {
 function editMaintenanceHandler (state = { }, action) {
   const {
     maintenance: updatedMaintenance
-  } = JSON.parse(action.response)
+  } = action.response
 
   const newMaintenances = state.maintenances.map((maintenance) => {
     if (maintenance.maintenanceID === updatedMaintenance.maintenanceID) {

--- a/packages/frontend/src/reducers/metrics.js
+++ b/packages/frontend/src/reducers/metrics.js
@@ -2,7 +2,7 @@ import { LIST_METRICS, LIST_EXTERNAL_METRICS, ADD_METRIC, EDIT_METRIC,
          REMOVE_METRIC, LIST_METRICS_DATA } from 'actions/metrics'
 
 function listMetricsHandler (state = { }, action) {
-  const newMetrics = JSON.parse(action.metrics)
+  const newMetrics = action.metrics
   state.metrics.forEach((metric) => {
     newMetrics.forEach((newMetric) => {
       if (newMetric.metricID === metric.metricID) newMetric.data = metric.data
@@ -15,7 +15,7 @@ function listMetricsHandler (state = { }, action) {
 }
 
 function listExternalMetricsHandler (state = { }, action) {
-  const fetchedMetrics = JSON.parse(action.metrics).metrics
+  const fetchedMetrics = action.metrics
 
   const existingMetrics = (state.externalMetrics && state.externalMetrics[action.metricsType]
                            ? state.externalMetrics[action.metricsType] : [])
@@ -32,13 +32,13 @@ function addMetricHandler (state = { }, action) {
   return Object.assign({}, state, {
     metrics: [
       ...state.metrics,
-      JSON.parse(action.metric)
+      action.metric
     ]
   })
 }
 
 function editMetricHandler (state = { }, action) {
-  let editedMetric = JSON.parse(action.metric)
+  let editedMetric = action.metric
 
   const newMetrics = state.metrics.map((metric) => {
     if (metric.metricID === editedMetric.metricID) {

--- a/packages/frontend/src/reducers/metrics.js
+++ b/packages/frontend/src/reducers/metrics.js
@@ -15,15 +15,13 @@ function listMetricsHandler (state = { }, action) {
 }
 
 function listExternalMetricsHandler (state = { }, action) {
-  const fetchedMetrics = action.metrics
-
-  const existingMetrics = (state.externalMetrics && state.externalMetrics[action.metricsType]
-                           ? state.externalMetrics[action.metricsType] : [])
-  const mergedMetrics = fetchedMetrics.concat(existingMetrics)
   return Object.assign({}, state, {
     externalMetrics: {
       ...state.externalMetrics,
-      [action.metricsType]: mergedMetrics
+      [action.metricsType]: {
+        filters: action.filters,
+        metrics: action.metrics
+      }
     }
   })
 }

--- a/packages/frontend/src/reducers/settings.js
+++ b/packages/frontend/src/reducers/settings.js
@@ -2,13 +2,13 @@ import { LIST_SETTINGS, EDIT_SETTINGS } from 'actions/settings'
 
 function listSettingsHandler (state = { }, action) {
   return Object.assign({}, state, {
-    settings: JSON.parse(action.settings)
+    settings: action.settings
   })
 }
 
 function editSettingsHandler (state = { }, action) {
   return Object.assign({}, state, {
-    settings: JSON.parse(action.settings)
+    settings: action.settings
   })
 }
 

--- a/packages/frontend/src/utils/status.js
+++ b/packages/frontend/src/utils/status.js
@@ -120,3 +120,20 @@ export const getNumDates = (timeframe) => {
       return 30
   }
 }
+
+export const regions = [
+  {id: 'us-east-1', name: 'US East (N. Virginia)'},
+  {id: 'us-east-2', name: 'US East (Ohio)'},
+  {id: 'us-west-1', name: 'US West (N. California)'},
+  {id: 'us-west-2', name: 'US West (Oregon)'},
+  {id: 'ca-central-1', name: 'Canada (Central)'},
+  {id: 'eu-west-1', name: 'EU (Ireland)'},
+  {id: 'eu-central-1', name: 'EU (Frankfurt)'},
+  {id: 'eu-west-2', name: 'EU (London)'},
+  {id: 'ap-northeast-1', name: 'Asia Pacific (Tokyo)'},
+  {id: 'ap-northeast-2', name: 'Asia Pacific (Seoul)'},
+  {id: 'ap-southeast-1', name: 'Asia Pacific (Singapore)'},
+  {id: 'ap-southeast-2', name: 'Asia Pacific (Sydney)'},
+  {id: 'ap-south-1', name: 'Asia Pacific (Mumbai)'},
+  {id: 'sa-east-1', name: 'South America (São Paulo)'}
+]

--- a/packages/frontend/tests/reducers/components.spec.js
+++ b/packages/frontend/tests/reducers/components.spec.js
@@ -19,7 +19,7 @@ describe('(Reducer) components', () => {
 
   describe('listComponentsHandler', () => {
     it('Should update the `components` state.', () => {
-      const state = componentsReducer(undefined, listComponents(JSON.stringify([comp1])))
+      const state = componentsReducer(undefined, listComponents([comp1]))
       assert.deepEqual([comp1], state.components)
     })
   })
@@ -28,7 +28,7 @@ describe('(Reducer) components', () => {
     it('Should update the `components` state.', () => {
       const state = componentsReducer({
         components: [comp1]
-      }, addComponent(JSON.stringify(comp2)))
+      }, addComponent(comp2))
       assert.deepEqual([comp1, comp2], state.components)
     })
   })
@@ -40,7 +40,7 @@ describe('(Reducer) components', () => {
       })
       const state = componentsReducer({
         components: [comp1]
-      }, editComponent(JSON.stringify(newComp1)))
+      }, editComponent(newComp1))
       assert.deepEqual([newComp1], state.components)
     })
   })

--- a/packages/frontend/tests/reducers/incidents.spec.js
+++ b/packages/frontend/tests/reducers/incidents.spec.js
@@ -24,7 +24,7 @@ describe('(Reducer) incidents', () => {
 
   describe('listIncidentsHandler', () => {
     it('Should update the `incidents` state.', () => {
-      const state = incidentsReducer(undefined, listIncidents(JSON.stringify([incident1])))
+      const state = incidentsReducer(undefined, listIncidents([incident1]))
       assert.deepEqual([incident1], state.incidents)
     })
   })
@@ -32,7 +32,7 @@ describe('(Reducer) incidents', () => {
   describe('listIncidentUpdatesHandler', () => {
     it('Should update the `incidents` state.', () => {
       const state = incidentsReducer({incidents: [incident1]},
-        listIncidentUpdates(JSON.stringify([incidentUpdate1]), '1'))
+        listIncidentUpdates([incidentUpdate1], '1'))
       assert.deepEqual([Object.assign({}, incident1, {
         incidentUpdates: [incidentUpdate1]
       })], state.incidents)
@@ -41,7 +41,7 @@ describe('(Reducer) incidents', () => {
 
   describe('addIncidentHandler', () => {
     it('Should update the `incidents` state.', () => {
-      const state = incidentsReducer({incidents: [incident1]}, addIncident(JSON.stringify({incident: incident2})))
+      const state = incidentsReducer({incidents: [incident1]}, addIncident({incident: incident2}))
       assert.deepEqual([incident2, incident1], state.incidents)
     })
   })
@@ -51,7 +51,7 @@ describe('(Reducer) incidents', () => {
       const newIncident1 = Object.assign({}, incident1, {
         name: 'newname'
       })
-      const state = incidentsReducer({incidents: [incident1]}, editIncident(JSON.stringify({incident: newIncident1})))
+      const state = incidentsReducer({incidents: [incident1]}, editIncident({incident: newIncident1}))
       assert.deepEqual([newIncident1], state.incidents)
     })
   })

--- a/packages/frontend/tests/reducers/maintenances.spec.js
+++ b/packages/frontend/tests/reducers/maintenances.spec.js
@@ -24,7 +24,7 @@ describe('(Reducer) maintenances', () => {
 
   describe('listMaintenancesHandler', () => {
     it('Should update the `maintenances` state.', () => {
-      const state = maintenancesReducer(undefined, listMaintenances(JSON.stringify([maintenance1])))
+      const state = maintenancesReducer(undefined, listMaintenances([maintenance1]))
       assert.deepEqual([maintenance1], state.maintenances)
     })
   })
@@ -32,7 +32,7 @@ describe('(Reducer) maintenances', () => {
   describe('listMaintenanceUpdatesHandler', () => {
     it('Should update the `maintenances` state.', () => {
       const state = maintenancesReducer({maintenances: [maintenance1]},
-        listMaintenanceUpdates(JSON.stringify([maintenanceUpdate1]), '1'))
+        listMaintenanceUpdates([maintenanceUpdate1], '1'))
       assert.deepEqual([Object.assign({}, maintenance1, {
         maintenanceUpdates: [maintenanceUpdate1]
       })], state.maintenances)
@@ -41,7 +41,7 @@ describe('(Reducer) maintenances', () => {
 
   describe('addMaintenanceHandler', () => {
     it('Should update the `maintenances` state.', () => {
-      const state = maintenancesReducer({maintenances: [maintenance1]}, addMaintenance(JSON.stringify({maintenance: maintenance2})))
+      const state = maintenancesReducer({maintenances: [maintenance1]}, addMaintenance({maintenance: maintenance2}))
       assert.deepEqual([maintenance2, maintenance1], state.maintenances)
     })
   })
@@ -51,7 +51,7 @@ describe('(Reducer) maintenances', () => {
       const newMaintenance1 = Object.assign({}, maintenance1, {
         name: 'newname'
       })
-      const state = maintenancesReducer({maintenances: [maintenance1]}, editMaintenance(JSON.stringify({maintenance: newMaintenance1})))
+      const state = maintenancesReducer({maintenances: [maintenance1]}, editMaintenance({maintenance: newMaintenance1}))
       assert.deepEqual([newMaintenance1], state.maintenances)
     })
   })

--- a/packages/lambda/src/api/getComponents/index.js
+++ b/packages/lambda/src/api/getComponents/index.js
@@ -4,7 +4,7 @@ export async function handle (event, context, callback) {
   try {
     let comps = await new Components().all()
     comps = comps.sort((a, b) => a.order - b.order)
-    callback(null, JSON.stringify(comps.map(comp => comp.objectify())))
+    callback(null, comps.map(comp => comp.objectify()))
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getExternalMetrics/index.js
+++ b/packages/lambda/src/api/getExternalMetrics/index.js
@@ -3,7 +3,7 @@ import { Metrics } from 'model/metrics'
 export async function handle (event, context, callback) {
   try {
     const externalMetrics = await new Metrics().listExternal(event.type, event.cursor)
-    callback(null, JSON.stringify(externalMetrics))
+    callback(null, externalMetrics)
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getExternalMetrics/index.js
+++ b/packages/lambda/src/api/getExternalMetrics/index.js
@@ -2,7 +2,7 @@ import { Metrics } from 'model/metrics'
 
 export async function handle (event, context, callback) {
   try {
-    const externalMetrics = await new Metrics().listExternal(event.type, event.cursor)
+    const externalMetrics = await new Metrics().listExternal(event.type, event.cursor, JSON.parse(event.filters))
     callback(null, externalMetrics)
   } catch (error) {
     console.log(error.message)

--- a/packages/lambda/src/api/getIncidentUpdates/index.js
+++ b/packages/lambda/src/api/getIncidentUpdates/index.js
@@ -5,7 +5,7 @@ export async function handle (event, context, callback) {
     const incidents = new Incidents()
     const incident = await incidents.lookup(event.params.incidentid)
     const incidentUpdates = await incident.getIncidentUpdates()
-    callback(null, JSON.stringify(incidentUpdates))
+    callback(null, incidentUpdates)
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getIncidents/index.js
+++ b/packages/lambda/src/api/getIncidents/index.js
@@ -3,7 +3,7 @@ import { Incidents } from 'model/incidents'
 export async function handle (event, context, callback) {
   try {
     const incidents = await new Incidents().all()
-    callback(null, JSON.stringify(incidents.map(incident => incident.objectify())))
+    callback(null, incidents.map(incident => incident.objectify()))
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getMaintenanceUpdates/index.js
+++ b/packages/lambda/src/api/getMaintenanceUpdates/index.js
@@ -5,7 +5,7 @@ export async function handle (event, context, callback) {
     const maintenances = new Maintenances()
     const maintenance = await maintenances.lookup(event.params.maintenanceid)
     const maintenanceUpdates = await maintenance.getMaintenanceUpdates()
-    callback(null, JSON.stringify(maintenanceUpdates))
+    callback(null, maintenanceUpdates)
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getMaintenances/index.js
+++ b/packages/lambda/src/api/getMaintenances/index.js
@@ -3,7 +3,7 @@ import { Maintenances } from 'model/maintenances'
 export async function handle (event, context, callback) {
   try {
     const maintenances = await new Maintenances().all()
-    callback(null, JSON.stringify(maintenances.map(maintenance => maintenance.objectify())))
+    callback(null, maintenances.map(maintenance => maintenance.objectify()))
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getMetrics/index.js
+++ b/packages/lambda/src/api/getMetrics/index.js
@@ -4,7 +4,7 @@ export async function handle (event, context, callback) {
   try {
     let metrics = await new Metrics().list()
     metrics = metrics.sort((a, b) => a.order - b.order)
-    callback(null, JSON.stringify(metrics.map(metric => metric.objectify())))
+    callback(null, metrics.map(metric => metric.objectify()))
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getPublicMetrics/index.js
+++ b/packages/lambda/src/api/getPublicMetrics/index.js
@@ -4,7 +4,7 @@ export async function handle (event, context, callback) {
   try {
     let metrics = await new Metrics().listPublic()
     metrics = metrics.sort((a, b) => a.order - b.order)
-    callback(null, JSON.stringify(metrics.map(metric => metric.objectify())))
+    callback(null, metrics.map(metric => metric.objectify()))
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getPublicSettings/index.js
+++ b/packages/lambda/src/api/getPublicSettings/index.js
@@ -5,7 +5,7 @@ export async function handle (event, context, callback) {
     const settings = new Settings()
     const serviceName = await settings.getServiceName()
     const statusPageURL = await settings.getStatusPageURL()
-    callback(null, JSON.stringify({serviceName, statusPageURL}))
+    callback(null, {serviceName, statusPageURL})
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/getSettings/index.js
+++ b/packages/lambda/src/api/getSettings/index.js
@@ -6,7 +6,7 @@ export async function handle (event, context, callback) {
     const serviceName = await settings.getServiceName()
     const adminPageURL = await settings.getAdminPageURL()
     const statusPageURL = await settings.getStatusPageURL()
-    callback(null, JSON.stringify({serviceName, adminPageURL, statusPageURL}))
+    callback(null, {serviceName, adminPageURL, statusPageURL})
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/patchComponents/index.js
+++ b/packages/lambda/src/api/patchComponents/index.js
@@ -6,7 +6,7 @@ export async function handle (event, context, callback) {
                                event.body.description, event.body.status, event.body.order)
     await comp.validate()
     await comp.save()
-    callback(null, JSON.stringify(comp.objectify()))
+    callback(null, comp.objectify())
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/patchIncidents/index.js
+++ b/packages/lambda/src/api/patchIncidents/index.js
@@ -13,10 +13,10 @@ export async function handle (event, context, callback) {
     const obj = incident.objectify()
     const comps = obj.components
     delete obj.components
-    callback(null, JSON.stringify({
+    callback(null, {
       incident: obj,
       components: comps
-    }))
+    })
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/patchMaintenances/index.js
+++ b/packages/lambda/src/api/patchMaintenances/index.js
@@ -14,10 +14,10 @@ export async function handle (event, context, callback) {
     const obj = maintenance.objectify()
     const comps = obj.components
     delete obj.components
-    callback(null, JSON.stringify({
+    callback(null, {
       maintenance: obj,
       components: comps
-    }))
+    })
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/patchMetrics/index.js
+++ b/packages/lambda/src/api/patchMetrics/index.js
@@ -6,7 +6,7 @@ export async function handle (event, context, callback) {
                               event.body.description, event.body.status, event.body.order, event.body.props)
     await metric.validate()
     await metric.save()
-    callback(null, JSON.stringify(metric.objectify()))
+    callback(null, metric.objectify())
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/patchSettings/index.js
+++ b/packages/lambda/src/api/patchSettings/index.js
@@ -17,7 +17,7 @@ export async function handle (event, context, callback) {
     if (statusPageURL !== undefined && statusPageURL !== await settings.getStatusPageURL()) {
       await settings.setStatusPageURL(statusPageURL)
     }
-    callback(null, JSON.stringify({serviceName, adminPageURL, statusPageURL}))
+    callback(null, {serviceName, adminPageURL, statusPageURL})
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/postComponents/index.js
+++ b/packages/lambda/src/api/postComponents/index.js
@@ -5,7 +5,7 @@ export async function handle (event, context, callback) {
     const comp = new Component(undefined, event.name, event.description, event.status, event.order)
     await comp.validate()
     await comp.save()
-    callback(null, JSON.stringify(comp.objectify()))
+    callback(null, comp.objectify())
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/postIncidents/index.js
+++ b/packages/lambda/src/api/postIncidents/index.js
@@ -13,10 +13,10 @@ export async function handle (event, context, callback) {
     const obj = incident.objectify()
     const comps = obj.components
     delete obj.components
-    callback(null, JSON.stringify({
+    callback(null, {
       incident: obj,
       components: comps
-    }))
+    })
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/postMaintenances/index.js
+++ b/packages/lambda/src/api/postMaintenances/index.js
@@ -13,10 +13,10 @@ export async function handle (event, context, callback) {
     const obj = maintenance.objectify()
     const comps = obj.components
     delete obj.components
-    callback(null, JSON.stringify({
+    callback(null, {
       maintenance: obj,
       components: comps
-    }))
+    })
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/postMetrics/index.js
+++ b/packages/lambda/src/api/postMetrics/index.js
@@ -6,7 +6,7 @@ export async function handle (event, context, callback) {
                               event.description, event.status, event.order, event.props)
     await metric.validate()
     await metric.save()
-    callback(null, JSON.stringify(metric.objectify()))
+    callback(null, metric.objectify())
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/aws/cloudWatch.js
+++ b/packages/lambda/src/aws/cloudWatch.js
@@ -29,7 +29,8 @@ export default class CloudWatch {
     const {
       Namespace: namespace,
       MetricName: metricName,
-      Dimensions: dimensions
+      Dimensions: dimensions,
+      Region: region
     } = props
     let period = 60
     let twoWeeksBefore = new Date()
@@ -39,7 +40,7 @@ export default class CloudWatch {
       period = 300
     }
 
-    const cloudWatch = new AWS.CloudWatch()
+    const cloudWatch = new AWS.CloudWatch({region})
     return new Promise((resolve, reject) => {
       const params = {
         Namespace: namespace,

--- a/packages/lambda/src/aws/cloudWatch.js
+++ b/packages/lambda/src/aws/cloudWatch.js
@@ -1,8 +1,12 @@
 import AWS from 'aws-sdk'
 
 export default class CloudWatch {
-  listMetrics (nextToken = undefined) {
-    const cloudWatch = new AWS.CloudWatch()
+  listMetrics (nextToken = undefined, filters = {}) {
+    let { AWS_REGION: region } = process.env
+    if (filters && filters.region) {
+      region = filters.region
+    }
+    const cloudWatch = new AWS.CloudWatch({region})
     return new Promise((resolve, reject) => {
       let params = {}
       if (nextToken) {

--- a/packages/lambda/src/model/metrics.js
+++ b/packages/lambda/src/model/metrics.js
@@ -93,9 +93,9 @@ export class Metric {
 }
 
 export class Metrics {
-  async listExternal (type, cursor) {
+  async listExternal (type, cursor, filters) {
     // TODO: should be instantiated based on 'type'
-    return await new CloudWatch().listMetrics(cursor)
+    return await new CloudWatch().listMetrics(cursor, filters)
   }
 
   async listPublic () {

--- a/packages/lambda/test/api/getComponents/index.js
+++ b/packages/lambda/test/api/getComponents/index.js
@@ -13,11 +13,11 @@ describe('getComponents', () => {
       new Component('2', undefined, undefined, undefined, 2),
       new Component('1', undefined, undefined, undefined, 1)
     ]
-    sinon.stub(Components.prototype, 'all').returns(components)
+    sinon.stub(Components.prototype, 'all').returns(components.slice(0))
 
     return await handle({}, null, (error, result) => {
       assert(error === null)
-      assert(result === JSON.stringify([{componentID: '1', order: 1}, {componentID: '2', order: 2}]))
+      assert.deepEqual(result, [components[1].objectify(), components[0].objectify()])
     })
   })
 

--- a/packages/lambda/test/api/getMaintenanceUpdates/index.js
+++ b/packages/lambda/test/api/getMaintenanceUpdates/index.js
@@ -17,7 +17,7 @@ describe('getMaintenanceUpdates', () => {
 
     return await handle({ params: { maintenanceid: '1' } }, null, (error, result) => {
       assert(error === null)
-      assert(result === JSON.stringify(maintenanceUpdates))
+      assert.deepEqual(result, maintenanceUpdates)
     })
   })
 

--- a/packages/lambda/test/api/getMaintenances/index.js
+++ b/packages/lambda/test/api/getMaintenances/index.js
@@ -12,11 +12,11 @@ describe('getMaintenances', () => {
     const maintenances = [
       new Maintenance('1', undefined, undefined, undefined, undefined, undefined, [], '1')
     ]
-    sinon.stub(Maintenances.prototype, 'all').returns(maintenances)
+    sinon.stub(Maintenances.prototype, 'all').returns(maintenances.slice(0))
 
     return await handle({}, null, (error, result) => {
       assert(error === null)
-      assert(result === JSON.stringify([{maintenanceID: '1', components: [], updatedAt: '1'}]))
+      assert.deepEqual(result, [maintenances[0].objectify()])
     })
   })
 

--- a/packages/lambda/test/api/getMetrics/index.js
+++ b/packages/lambda/test/api/getMetrics/index.js
@@ -13,11 +13,11 @@ describe('getMetrics', () => {
       new Metric('2', undefined, undefined, undefined, undefined, undefined, 2, undefined),
       new Metric('1', undefined, undefined, undefined, undefined, undefined, 1, undefined)
     ]
-    sinon.stub(Metrics.prototype, 'list').returns(metrics)
+    sinon.stub(Metrics.prototype, 'list').returns(metrics.slice(0))
 
     return await handle({}, null, (error, result) => {
       assert(error === null)
-      assert(result === JSON.stringify([{metricID: '1', order: 1}, {metricID: '2', order: 2}]))
+      assert.deepEqual(result, [metrics[1].objectify(), metrics[0].objectify()])
     })
   })
 

--- a/packages/lambda/test/api/getPublicMetrics/index.js
+++ b/packages/lambda/test/api/getPublicMetrics/index.js
@@ -13,11 +13,11 @@ describe('getPublicMetrics', () => {
       new Metric('2', undefined, undefined, undefined, undefined, undefined, 2, undefined),
       new Metric('1', undefined, undefined, undefined, undefined, undefined, 1, undefined)
     ]
-    sinon.stub(Metrics.prototype, 'listPublic').returns(metrics)
+    sinon.stub(Metrics.prototype, 'listPublic').returns(metrics.slice(0))
 
     return await handle({}, null, (error, result) => {
       assert(error === null)
-      assert(result === JSON.stringify([{metricID: '1', order: 1}, {metricID: '2', order: 2}]))
+      assert.deepEqual(result, [metrics[1].objectify(), metrics[0].objectify()])
     })
   })
 

--- a/packages/lambda/test/api/patchMaintenances/index.js
+++ b/packages/lambda/test/api/patchMaintenances/index.js
@@ -18,9 +18,8 @@ describe('patchMaintenances', () => {
 
     await handle({ params: { maintenanceid: '1' }, body: { components: [] } }, null, (error, result) => {
       assert(error === null)
-      const obj = JSON.parse(result)
-      assert(obj.maintenance.maintenanceID === '1')
-      assert.deepEqual(obj.components, [])
+      assert(result.maintenance.maintenanceID === '1')
+      assert.deepEqual(result.components, [])
     })
     assert(validateStub.calledOnce)
     assert(saveStub.calledOnce)

--- a/packages/lambda/test/api/postMaintenances/index.js
+++ b/packages/lambda/test/api/postMaintenances/index.js
@@ -18,9 +18,8 @@ describe('postMaintenances', () => {
 
     await handle({ components: [] }, null, (error, result) => {
       assert(error === null)
-      const obj = JSON.parse(result)
-      assert(obj.maintenance.maintenanceID.length === 12)
-      assert.deepEqual(obj.components, [])
+      assert(result.maintenance.maintenanceID.length === 12)
+      assert.deepEqual(result.components, [])
     })
     assert(validateStub.calledOnce)
     assert(saveStub.calledOnce)


### PR DESCRIPTION
Fixes https://github.com/ks888/LambStatus/issues/39
It is possible to choose the region to fetch the metrics using the UI like below:
<img width="561" alt="screen shot 2017-06-04 at 15 03 18" src="https://cloud.githubusercontent.com/assets/8448120/26759378/16d7ddfc-4937-11e7-876e-4f9619f5e8d6.png">

Also, the response from API gateway is stringified JSON. There is no need to stringify them. This PR fixes it, too.