### PR TITLE
Support custom domain

### DIFF
--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -3923,8 +3923,12 @@ Resources:
       Bucket:
         Ref: StatusPageS3
       Key: settings.js
-      Body: !Sub |-
-        __LAMBSTATUS_API_URL__ = 'https://${StatusPageDistribution.DomainName}';
+      Body: !Sub
+        - __LAMBSTATUS_API_URL__ = 'https://${Domain}';
+        - Domain: !If
+          - UseDefaultStatusPageURL
+          - !Sub ${StatusPageDistribution.DomainName}
+          - !Select ["0", !Ref StatusPageURL]
   AdminPageApiInfo:
     Type: Custom::S3PutObject
     Properties:
@@ -3937,8 +3941,12 @@ Resources:
       Bucket:
         Ref: AdminPageS3
       Key: settings.js
-      Body: !Sub |-
-        __LAMBSTATUS_API_URL__ = 'https://${AdminPageDistribution.DomainName}';__LAMBSTATUS_USER_POOL_ID__ = '${CognitoUserPool.UserPoolID}';__LAMBSTATUS_CLIENT_ID__ = '${CognitoUserPoolClient.UserPoolClientID}';
+      Body: !Sub
+        - __LAMBSTATUS_API_URL__ = 'https://${Domain}';__LAMBSTATUS_USER_POOL_ID__ = '${CognitoUserPool.UserPoolID}';__LAMBSTATUS_CLIENT_ID__ = '${CognitoUserPoolClient.UserPoolClientID}';
+        - Domain: !If
+          - UseDefaultAdminPageURL
+          - !Sub ${AdminPageDistribution.DomainName}
+          - !Select ["0", !Ref AdminPageURL]
   DBInitialItems:
     Type: Custom::DBCreateItems
     Properties:
@@ -3948,10 +3956,6 @@ Resources:
           - Arn
       CognitoPoolID: !Sub |-
         ${CognitoUserPool.UserPoolID}
-      AdminPageURL: !Sub |-
-        https://${AdminPageDistribution.DomainName}
-      StatusPageURL: !Sub |-
-        https://${StatusPageDistribution.DomainName}
       IncidentNotificationTopic:
         Ref: "IncidentNotificationTopic"
       UsagePlanID:
@@ -4016,8 +4020,12 @@ Resources:
           - Arn
       PoolName: !Sub |-
         ${AWS::StackName}
-      AdminPageURL: !Sub |-
-        https://${AdminPageDistribution.DomainName}
+      AdminPageURL: !Sub
+        - https://${Domain}
+        - Domain: !If
+          - UseDefaultAdminPageURL
+          - !Sub ${AdminPageDistribution.DomainName}
+          - !Select ["0", !Ref AdminPageURL]
       SnsCallerArn: !Sub |-
         ${CognitoSMSCallerRole.Arn}
   CognitoUserPoolClient:
@@ -4070,8 +4078,12 @@ Outputs:
     Value:
       Ref: "AdminPageS3"
   AdminPageCloudFrontURL:
-    Value: !Sub |-
-      https://${AdminPageDistribution.DomainName}
+    Value: !Sub
+      - https://${Domain}
+      - Domain: !If
+        - UseDefaultAdminPageURL
+        - !Sub ${AdminPageDistribution.DomainName}
+        - !Select ["0", !Ref AdminPageURL]
   StatusPageS3BucketURL:
     Value:
       Fn::GetAtt:
@@ -4082,8 +4094,12 @@ Outputs:
     Value:
       Ref: "StatusPageS3"
   StatusPageCloudFrontURL:
-    Value: !Sub |-
-      https://${StatusPageDistribution.DomainName}
+    Value: !Sub
+      - https://${Domain}
+      - Domain: !If
+        - UseDefaultStatusPageURL
+        - !Sub ${StatusPageDistribution.DomainName}
+        - !Select ["0", !Ref StatusPageURL]
   InvocationURL:
     Value: !Sub |-
       https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/prod/

--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -8,14 +8,35 @@ Parameters:
     Default: admin
     MinLength: 1
   UserEmail:
-    Description: Your email address. The initial login information will be sent to the address.
+    Description: Your email address. The initial login information will be sent to the address
     Type: String
     # The pattern is included in the error message, so the simpler pattern is preferable. Based on http://stackoverflow.com/a/8204716
     AllowedPattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+  StatusPageSSLCertificate:
+    Description: Optional. See github.com/ks888/LambStatus/wiki/CloudFormation-Parameters for usage
+    Type: String
+  StatusPageURL:
+    Description: Optional. See github.com/ks888/LambStatus/wiki/CloudFormation-Parameters for usage
+    Type: CommaDelimitedList
+  AdminPageSSLCertificate:
+    Description: Optional. See github.com/ks888/LambStatus/wiki/CloudFormation-Parameters for usage
+    Type: String
+  AdminPageURL:
+    Description: Optional. See github.com/ks888/LambStatus/wiki/CloudFormation-Parameters for usage
+    Type: CommaDelimitedList
 Mappings:
   Constants:
     LambStatus:
       Version: 0.4.2
+Conditions:
+  UseDefaultStatusPageSSLCertificate:
+    !Equals [ !Ref StatusPageSSLCertificate, "" ]
+  UseDefaultStatusPageURL:
+    !Equals [ !Join [ ",", !Ref StatusPageURL ], "" ]
+  UseDefaultAdminPageSSLCertificate:
+    !Equals [ !Ref AdminPageSSLCertificate, "" ]
+  UseDefaultAdminPageURL:
+    !Equals [ !Join [ ",", !Ref AdminPageURL ], "" ]
 Resources:
   LambdaRole:
     Type: AWS::IAM::Role
@@ -3476,9 +3497,22 @@ Resources:
                 - TLSv1
                 - TLSv1.1
                 - TLSv1.2
+        Aliases:
+          !If
+          - UseDefaultStatusPageURL
+          - !Ref AWS::NoValue
+          - !Ref StatusPageURL
         Enabled: "true"
         HttpVersion: "http2"
         Comment: "Distribution for status page of LambStatus"
+        ViewerCertificate:
+          !If
+            - UseDefaultStatusPageSSLCertificate
+            - !Ref AWS::NoValue
+            - MinimumProtocolVersion: TLSv1
+              SslSupportMethod: sni-only
+              AcmCertificateArn:
+                !Ref StatusPageSSLCertificate
         DefaultRootObject: "index.html"
         DefaultCacheBehavior:
           DefaultTTL: 0
@@ -3516,8 +3550,6 @@ Resources:
             Compress: "true"
             DefaultTTL: "10"
         PriceClass: "PriceClass_200"
-        ViewerCertificate:
-          CloudFrontDefaultCertificate: "true"
         CustomErrorResponses:
           - ErrorCachingMinTTL: 0
             ErrorCode: 404
@@ -3563,9 +3595,21 @@ Resources:
                 - TLSv1
                 - TLSv1.1
                 - TLSv1.2
+        Aliases:
+          !If
+          - UseDefaultAdminPageURL
+          - !Ref AWS::NoValue
+          - !Ref AdminPageURL
         Enabled: "true"
         HttpVersion: "http2"
         Comment: "Distribution for admin page of LambStatus"
+        ViewerCertificate:
+          !If
+            - UseDefaultAdminPageSSLCertificate
+            - !Ref AWS::NoValue
+            - SslSupportMethod: sni-only
+              AcmCertificateArn:
+                !Ref AdminPageSSLCertificate
         DefaultRootObject: "index.html"
         DefaultCacheBehavior:
           DefaultTTL: 0
@@ -3601,8 +3645,6 @@ Resources:
             Compress: "true"
             DefaultTTL: "0"
         PriceClass: "PriceClass_200"
-        ViewerCertificate:
-          CloudFrontDefaultCertificate: "true"
         CustomErrorResponses:
           - ErrorCachingMinTTL: 0
             ErrorCode: 404

--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -13,16 +13,16 @@ Parameters:
     # The pattern is included in the error message, so the simpler pattern is preferable. Based on http://stackoverflow.com/a/8204716
     AllowedPattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
   StatusPageSSLCertificate:
-    Description: Optional. See github.com/ks888/LambStatus/wiki/CloudFormation-Parameters for usage
+    Description: Optional. See github.com/ks888/LambStatus/wiki/Set-up-your-custom-domain for usage
     Type: String
   StatusPageURL:
-    Description: Optional. See github.com/ks888/LambStatus/wiki/CloudFormation-Parameters for usage
+    Description: Optional. See github.com/ks888/LambStatus/wiki/Set-up-your-custom-domain for usage
     Type: CommaDelimitedList
   AdminPageSSLCertificate:
-    Description: Optional. See github.com/ks888/LambStatus/wiki/CloudFormation-Parameters for usage
+    Description: Optional. See github.com/ks888/LambStatus/wiki/Set-up-your-custom-domain for usage
     Type: String
   AdminPageURL:
-    Description: Optional. See github.com/ks888/LambStatus/wiki/CloudFormation-Parameters for usage
+    Description: Optional. See github.com/ks888/LambStatus/wiki/Set-up-your-custom-domain for usage
     Type: CommaDelimitedList
 Mappings:
   Constants:

--- a/packages/frontend/src/actions/settings.js
+++ b/packages/frontend/src/actions/settings.js
@@ -61,10 +61,10 @@ export const fetchPublicSettings = (callbacks = {}) => {
   }
 }
 
-export const updateSettings = (serviceName, adminPageURL, statusPageURL, callbacks = {}) => {
+export const updateSettings = (serviceName, callbacks = {}) => {
   return async dispatch => {
     try {
-      const body = { serviceName, adminPageURL, statusPageURL }
+      const body = { serviceName }
       const json = await sendRequest(apiURL + '/api/settings', {
         headers: await buildHeaders(),
         method: 'PATCH',

--- a/packages/frontend/src/components/adminPage/Settings/Settings.js
+++ b/packages/frontend/src/components/adminPage/Settings/Settings.js
@@ -9,8 +9,6 @@ import classes from './Settings.scss'
 export default class Settings extends React.Component {
   static propTypes = {
     settings: PropTypes.shape({
-      adminPageURL: PropTypes.string,
-      statusPageURL: PropTypes.string,
       serviceName: PropTypes.string,
       apiKeys: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.string.isRequired,
@@ -29,8 +27,6 @@ export default class Settings extends React.Component {
     this.state = {
       isFetching: false,
       message: '',
-      adminPageURL: props.settings.adminPageURL || '',
-      statusPageURL: props.settings.statusPageURL || '',
       serviceName: props.settings.serviceName || '',
       apiKeys: props.settings.apiKeys ? props.settings.apiKeys.map(key => {
         return { ...key, status: apiKeyStatuses.created }
@@ -52,8 +48,6 @@ export default class Settings extends React.Component {
 
   componentWillReceiveProps (nextProps) {
     this.setState({
-      adminPageURL: nextProps.settings.adminPageURL,
-      statusPageURL: nextProps.settings.statusPageURL,
       serviceName: nextProps.settings.serviceName,
       apiKeys: nextProps.settings.apiKeys.map(key => {
         return { ...key, status: apiKeyStatuses.created }
@@ -103,8 +97,7 @@ export default class Settings extends React.Component {
           throw new Error('unknown status', key.status)
       }
     })
-    this.props.updateSettings(this.state.serviceName, this.state.adminPageURL, this.state.statusPageURL,
-                              this.callbacks)
+    this.props.updateSettings(this.state.serviceName, this.callbacks)
   }
 
   renderApiKeysSelector = () => {
@@ -130,9 +123,7 @@ export default class Settings extends React.Component {
     // eslint-disable-next-line
     const urlSettingInfo = 'Affects the links in email notifications, RSS feeds, and so on. It doesn\'t change your DNS setting.'
     const settings = [
-      {key: 'serviceName'},
-      {key: 'statusPageURL', info: urlSettingInfo},
-      {key: 'adminPageURL', info: urlSettingInfo}
+      {key: 'serviceName'}
     ]
     const settingItems = settings.map(this.renderItem)
     settingItems.push(this.renderApiKeysSelector())

--- a/packages/frontend/tests/actions/settings.spec.js
+++ b/packages/frontend/tests/actions/settings.spec.js
@@ -107,7 +107,7 @@ describe('Actions/Settings', () => {
     it('should update the existing settings.', () => {
       fetchMock.patch(/.*\/settings/, { body: settings, headers: {'Content-Type': 'application/json'} })
 
-      return updateSettings('', '', '', callbacks)(dispatchSpy)
+      return updateSettings('', callbacks)(dispatchSpy)
         .then(() => {
           assert(callbacks.onLoad.calledOnce)
           assert(callbacks.onSuccess.calledOnce)
@@ -121,7 +121,7 @@ describe('Actions/Settings', () => {
     it('should handle error properly.', () => {
       fetchMock.patch(/.*\/settings/, { status: 400, body: {} })
 
-      return updateSettings('', '', '', callbacks)(dispatchSpy)
+      return updateSettings('', callbacks)(dispatchSpy)
         .then(() => {
           assert(callbacks.onLoad.calledOnce)
           assert(!callbacks.onSuccess.called)

--- a/packages/frontend/tests/components/adminPage/Settings/Settings.spec.js
+++ b/packages/frontend/tests/components/adminPage/Settings/Settings.spec.js
@@ -8,8 +8,6 @@ describe('Settings', () => {
   const generateProps = () => {
     return {
       settings: {
-        adminPageURL: 'admin',
-        statusPageURL: 'status',
         serviceName: 'service',
         apiKeys: [{id: '1', value: '1'}, {id: '2', value: '2'}]
       },
@@ -24,8 +22,6 @@ describe('Settings', () => {
     it('should initialize the state', () => {
       const props = generateProps()
       const settings = shallow(<Settings {...props} />)
-      assert(settings.state('adminPageURL') === props.settings.adminPageURL)
-      assert(settings.state('statusPageURL') === props.settings.statusPageURL)
       assert(settings.state('serviceName') === props.settings.serviceName)
       assert.deepEqual(settings.state('apiKeys')[0].id, props.settings.apiKeys[0].id)
       assert.deepEqual(settings.state('apiKeys')[0].status, apiKeyStatuses.created)

--- a/packages/lambda/bin/deploy.js
+++ b/packages/lambda/bin/deploy.js
@@ -11,7 +11,7 @@ const targetFuncs = (process.argv.length === 2 ? undefined : process.argv.slice(
 
 const deploy = (cmd) => {
   return new Promise((resolve, reject) => {
-    exec(cmd, { cwd: buildDir, maxBuffer: 100 * 1024 * 1024, timeout: 10 * 1000 }, (error, stdout, stderr) => {
+    exec(cmd, { cwd: buildDir, maxBuffer: 100 * 1024 * 1024, timeout: 30 * 1000 }, (error, stdout, stderr) => {
       if (error) {
         reject(error)
         return

--- a/packages/lambda/src/api/cognitoCreateUserPool/index.js
+++ b/packages/lambda/src/api/cognitoCreateUserPool/index.js
@@ -2,32 +2,12 @@ import response from 'cfn-response'
 import Cognito, { UserPool } from 'aws/cognito'
 import { SettingsProxy } from 'api/utils'
 
-export async function handle (event, context, callback) {
+const createUserPool = async (event, context, poolID) => {
   const {
     PoolName: poolName,
     AdminPageURL: adminPageURL,
     SnsCallerArn: snsCallerArn
   } = event.ResourceProperties
-
-  if (event.RequestType === 'Delete') {
-    try {
-      const poolID = event.PhysicalResourceId
-      await new Cognito().deleteUserPool(poolID)
-      response.send(event, context, response.SUCCESS, {UserPoolID: poolID}, poolID)
-    } catch (error) {
-      console.log(error.message)
-      console.log(error.stack)
-      response.send(event, context, response.FAILED)
-    }
-    return
-  }
-
-  if (event.RequestType === 'Update') {
-    const poolID = event.PhysicalResourceId
-    // If `physicalResourceId` is changed, the custom resource will be deleted.
-    response.send(event, context, response.SUCCESS, {UserPoolID: poolID}, poolID)
-    return
-  }
 
   try {
     const settings = new SettingsProxy()
@@ -35,11 +15,59 @@ export async function handle (event, context, callback) {
 
     const userPool = new UserPool({userPoolName: poolName, serviceName, adminPageURL, snsCallerArn})
     const createdUserPool = await new Cognito().createUserPool(userPool)
+
     const poolID = createdUserPool.userPoolID
     response.send(event, context, response.SUCCESS, {UserPoolID: poolID}, poolID)
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)
     response.send(event, context, response.FAILED)
+  }
+}
+
+const updateUserPool = async (event, context) => {
+  const {
+    AdminPageURL: adminPageURL
+  } = event.ResourceProperties
+  const poolID = event.PhysicalResourceId
+
+  const cognito = new Cognito()
+  const userPool = await cognito.getUserPool(poolID)
+  const settings = new SettingsProxy()
+  userPool.serviceName = await settings.getServiceName()
+  userPool.adminPageURL = adminPageURL
+  await cognito.updateUserPool(userPool)
+
+  // Note: If `physicalResourceId` is changed, the custom resource will be deleted.
+  response.send(event, context, response.SUCCESS, {UserPoolID: poolID}, poolID)
+}
+
+const deleteUserPool = async (event, context) => {
+  const poolID = event.PhysicalResourceId
+
+  try {
+    await new Cognito().deleteUserPool(poolID)
+    response.send(event, context, response.SUCCESS, {UserPoolID: poolID}, poolID)
+  } catch (error) {
+    console.log(error.message)
+    console.log(error.stack)
+    response.send(event, context, response.FAILED)
+  }
+}
+
+export async function handle (event, context, callback) {
+  switch (event.RequestType) {
+    case 'Create':
+      await createUserPool(event, context)
+      break
+    case 'Update':
+      await updateUserPool(event, context)
+      break
+    case 'Delete':
+      await deleteUserPool(event, context)
+      break
+    default:
+      console.log('unknown request type:', event.RequestType)
+      response.send(event, context, response.FAILED)
   }
 }

--- a/packages/lambda/src/api/cognitoCreateUserPool/index.js
+++ b/packages/lambda/src/api/cognitoCreateUserPool/index.js
@@ -33,9 +33,9 @@ const updateUserPool = async (event, context) => {
 
   const cognito = new Cognito()
   const userPool = await cognito.getUserPool(poolID)
-  const settings = new SettingsProxy()
-  userPool.serviceName = await settings.getServiceName()
+  userPool.serviceName = await new SettingsProxy().getServiceName()
   userPool.adminPageURL = adminPageURL
+
   await cognito.updateUserPool(userPool)
 
   // Note: If `physicalResourceId` is changed, the custom resource will be deleted.

--- a/packages/lambda/src/api/dbCreateItems/index.js
+++ b/packages/lambda/src/api/dbCreateItems/index.js
@@ -32,9 +32,6 @@ export async function handle (event, context, callback) {
   try {
     await new SNS().notifyIncidentToTopic(incidentNotificationTopic)
 
-    if (adminPageURL) {
-      await settings.setAdminPageURL(adminPageURL)
-    }
     if (cognitoPoolID) {
       await settings.setCognitoPoolID(cognitoPoolID)
     }

--- a/packages/lambda/src/api/dbCreateItems/index.js
+++ b/packages/lambda/src/api/dbCreateItems/index.js
@@ -11,24 +11,12 @@ export async function handle (event, context, callback) {
   }
 
   const {
-    AdminPageURL: adminPageURL,
-    StatusPageURL: statusPageURL,
     CognitoPoolID: cognitoPoolID,
     IncidentNotificationTopic: incidentNotificationTopic,
     UsagePlanID: usagePlanID
   } = event.ResourceProperties
 
   const settings = new SettingsProxy()
-  try {
-    if (statusPageURL) {
-      await settings.setStatusPageURL(statusPageURL)
-    }
-  } catch (error) {
-    // setStatusPageURL always fails due to the unknown SNS topic. So ignore the error here.
-    // TODO: improve error handling. There may be other kinds of errors.
-    console.warn(error.message)
-  }
-
   try {
     await new SNS().notifyIncidentToTopic(incidentNotificationTopic)
 

--- a/packages/lambda/src/api/patchSettings/index.js
+++ b/packages/lambda/src/api/patchSettings/index.js
@@ -2,18 +2,14 @@ import { SettingsProxy } from 'api/utils'
 
 export async function handle (event, context, callback) {
   const {
-    serviceName,
-    statusPageURL
+    serviceName
   } = event.body
   try {
     const settings = new SettingsProxy()
     if (serviceName !== undefined && serviceName !== await settings.getServiceName()) {
       await settings.setServiceName(serviceName)
     }
-    if (statusPageURL !== undefined && statusPageURL !== await settings.getStatusPageURL()) {
-      await settings.setStatusPageURL(statusPageURL)
-    }
-    callback(null, {serviceName, adminPageURL, statusPageURL})
+    callback(null, {serviceName})
   } catch (error) {
     console.log(error.message)
     console.log(error.stack)

--- a/packages/lambda/src/api/patchSettings/index.js
+++ b/packages/lambda/src/api/patchSettings/index.js
@@ -3,16 +3,12 @@ import { SettingsProxy } from 'api/utils'
 export async function handle (event, context, callback) {
   const {
     serviceName,
-    adminPageURL,
     statusPageURL
   } = event.body
   try {
     const settings = new SettingsProxy()
     if (serviceName !== undefined && serviceName !== await settings.getServiceName()) {
       await settings.setServiceName(serviceName)
-    }
-    if (adminPageURL !== undefined && adminPageURL !== await settings.getAdminPageURL()) {
-      await settings.setAdminPageURL(adminPageURL)
     }
     if (statusPageURL !== undefined && statusPageURL !== await settings.getStatusPageURL()) {
       await settings.setStatusPageURL(statusPageURL)

--- a/packages/lambda/src/api/utils.js
+++ b/packages/lambda/src/api/utils.js
@@ -23,7 +23,7 @@ export class SettingsProxy {
   constructor (params) {
     this.settings = new Settings(params)
     this.store = new SettingsStore()
-    this.cloudFormation = new CloudFormation()
+    this.cloudFormation = new CloudFormation(stackName)
     this.sns = new SNS()
   }
 

--- a/packages/lambda/src/api/utils.js
+++ b/packages/lambda/src/api/utils.js
@@ -23,6 +23,7 @@ export class SettingsProxy {
   constructor (params) {
     this.settings = new Settings(params)
     this.store = new SettingsStore()
+    this.cloudFormation = new CloudFormation()
     this.sns = new SNS()
   }
 
@@ -45,20 +46,13 @@ export class SettingsProxy {
     return storedServiceName
   }
 
-  async setAdminPageURL (adminPageURL) {
-    await this.settings.setAdminPageURL(adminPageURL)
-
-    await this.store.setAdminPageURL(await this.settings.getAdminPageURL())
-    await this.updateUserPool()
-  }
-
   async getAdminPageURL () {
     const adminPageURL = await this.settings.getAdminPageURL()
     if (adminPageURL !== undefined) {
       return adminPageURL
     }
 
-    const storedAdminPageURL = await this.store.getAdminPageURL()
+    const storedAdminPageURL = await this.cloudFormation.getAdminPageCloudFrontURL()
     await this.settings.setAdminPageURL(storedAdminPageURL)
     return storedAdminPageURL
   }

--- a/packages/lambda/src/api/utils.js
+++ b/packages/lambda/src/api/utils.js
@@ -57,20 +57,13 @@ export class SettingsProxy {
     return storedAdminPageURL
   }
 
-  async setStatusPageURL (statusPageURL) {
-    await this.settings.setStatusPageURL(statusPageURL)
-
-    await this.store.setStatusPageURL(await this.settings.getStatusPageURL())
-    await this.sns.notifyIncident()
-  }
-
   async getStatusPageURL () {
     const statusPageURL = await this.settings.getStatusPageURL()
     if (statusPageURL !== undefined) {
       return statusPageURL
     }
 
-    const storedStatusPageURL = await this.store.getStatusPageURL()
+    const storedStatusPageURL = await this.cloudFormation.getStatusPageCloudFrontURL()
     await this.settings.setStatusPageURL(storedStatusPageURL)
     return storedStatusPageURL
   }

--- a/packages/lambda/src/aws/cloudFormation.js
+++ b/packages/lambda/src/aws/cloudFormation.js
@@ -45,6 +45,11 @@ export default class CloudFormation {
     return value
   }
 
+  async getAdminPageCloudFrontURL () {
+    const key = 'AdminPageCloudFrontURL'
+    return await this.getOutputValue(key)
+  }
+
   async getAdminPageBucketName () {
     const key = 'AdminPageS3BucketName'
     return await this.getOutputValue(key)

--- a/packages/lambda/src/aws/cloudFormation.js
+++ b/packages/lambda/src/aws/cloudFormation.js
@@ -55,6 +55,11 @@ export default class CloudFormation {
     return await this.getOutputValue(key)
   }
 
+  async getStatusPageCloudFrontURL () {
+    const key = 'StatusPageCloudFrontURL'
+    return await this.getOutputValue(key)
+  }
+
   async getStatusPageBucketName () {
     const key = 'StatusPageS3BucketName'
     return await this.getOutputValue(key)

--- a/packages/lambda/src/db/settings.js
+++ b/packages/lambda/src/db/settings.js
@@ -9,7 +9,6 @@ import { buildUpdateExpression } from './utils'
 export const settingKeys = {
   serviceName: 'ServiceName',
   statusPageURL: 'StatusPageURL',
-  adminPageURL: 'AdminPageURL',
   cognitoPoolID: 'CognitoPoolID'
 }
 
@@ -46,21 +45,6 @@ export default class SettingsStore {
 
   async setStatusPageURL (name) {
     return await this.store.set(settingKeys.statusPageURL, name)
-  }
-
-  async getAdminPageURL () {
-    try {
-      return await this.store.get(settingKeys.adminPageURL)
-    } catch (err) {
-      if (err.name === NotFoundError.name) {
-        return ''
-      }
-      throw err
-    }
-  }
-
-  async setAdminPageURL (name) {
-    return await this.store.set(settingKeys.adminPageURL, name)
   }
 
   async getCognitoPoolID () {

--- a/packages/lambda/src/db/settings.js
+++ b/packages/lambda/src/db/settings.js
@@ -8,7 +8,6 @@ import { buildUpdateExpression } from './utils'
 
 export const settingKeys = {
   serviceName: 'ServiceName',
-  statusPageURL: 'StatusPageURL',
   cognitoPoolID: 'CognitoPoolID'
 }
 
@@ -30,21 +29,6 @@ export default class SettingsStore {
 
   async setServiceName (name) {
     return await this.store.set(settingKeys.serviceName, name)
-  }
-
-  async getStatusPageURL () {
-    try {
-      return await this.store.get(settingKeys.statusPageURL)
-    } catch (err) {
-      if (err.name === NotFoundError.name) {
-        return ''
-      }
-      throw err
-    }
-  }
-
-  async setStatusPageURL (name) {
-    return await this.store.set(settingKeys.statusPageURL, name)
   }
 
   async getCognitoPoolID () {

--- a/packages/lambda/src/model/settings.js
+++ b/packages/lambda/src/model/settings.js
@@ -1,16 +1,9 @@
-import { ValidationError } from 'utils/errors'
-
 export class Settings {
   constructor ({serviceName, adminPageURL, statusPageURL, cognitoPoolID} = {}) {
     this.serviceName = serviceName
     this.adminPageURL = adminPageURL
     this.statusPageURL = statusPageURL
     this.cognitoPoolID = cognitoPoolID
-  }
-
-  validate (url) {
-    // eslint-disable-next-line no-useless-escape, max-len
-    return url.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g) !== null
   }
 
   async setServiceName (serviceName) {
@@ -22,9 +15,6 @@ export class Settings {
   }
 
   async setAdminPageURL (adminPageURL) {
-    if (!this.validate(adminPageURL)) {
-      throw new ValidationError('invalid url')
-    }
     this.adminPageURL = adminPageURL
   }
 
@@ -33,9 +23,6 @@ export class Settings {
   }
 
   async setStatusPageURL (statusPageURL) {
-    if (!this.validate(statusPageURL)) {
-      throw new ValidationError('invalid url')
-    }
     this.statusPageURL = statusPageURL
   }
 

--- a/packages/lambda/test/api/cognitoCreateUserPool/index.js
+++ b/packages/lambda/test/api/cognitoCreateUserPool/index.js
@@ -1,0 +1,90 @@
+import assert from 'assert'
+import sinon from 'sinon'
+import { handle } from 'api/cognitoCreateUserPool'
+import response from 'cfn-response'
+import Cognito from 'aws/cognito'
+import { SettingsProxy } from 'api/utils'
+
+describe('cognitoCreateUserPool', () => {
+  describe('Create request type', () => {
+    afterEach(() => {
+      SettingsProxy.prototype.getServiceName.restore()
+      Cognito.prototype.createUserPool.restore()
+      response.send.restore()
+    })
+
+    it('should create a new user pool', async () => {
+      const event = {
+        RequestType: 'Create',
+        ResourceProperties: {
+          PoolName: 'poolName',
+          AdminPageURL: 'example.com',
+          SnsCallerArn: 'arn:...'
+        }
+      }
+      sinon.stub(SettingsProxy.prototype, 'getServiceName').returns('serviceName')
+      const createStub = sinon.stub(Cognito.prototype, 'createUserPool').returns({userPoolID: 'id'})
+      const sendStub = sinon.stub(response, 'send').returns()
+
+      await handle(event, null, null)
+      assert(sendStub.calledOnce)
+      assert(sendStub.firstCall.args[2] === response.SUCCESS)
+      assert(createStub.calledOnce)
+      assert(createStub.firstCall.args[0].userPoolName === event.ResourceProperties.PoolName)
+    })
+  })
+
+  describe('Update request type', () => {
+    afterEach(() => {
+      SettingsProxy.prototype.getServiceName.restore()
+      Cognito.prototype.getUserPool.restore()
+      Cognito.prototype.updateUserPool.restore()
+      response.send.restore()
+    })
+
+    it('should update the existing user pool', async () => {
+      const event = {
+        RequestType: 'Update',
+        PhysicalResourceId: 'id',
+        ResourceProperties: {
+          AdminPageURL: 'example.com'
+        }
+      }
+      const serviceName = 'serviceName'
+      sinon.stub(SettingsProxy.prototype, 'getServiceName').returns(serviceName)
+      sinon.stub(Cognito.prototype, 'getUserPool').returns({})
+      const updateStub = sinon.stub(Cognito.prototype, 'updateUserPool').returns()
+      const sendStub = sinon.stub(response, 'send').returns()
+
+      await handle(event, null, null)
+      assert(sendStub.calledOnce)
+      assert(sendStub.firstCall.args[2] === response.SUCCESS)
+      assert(updateStub.calledOnce)
+      assert(updateStub.firstCall.args[0].adminPageURL === event.ResourceProperties.AdminPageURL)
+      assert(updateStub.firstCall.args[0].serviceName === serviceName)
+    })
+  })
+
+  describe('Delete request type', () => {
+    afterEach(() => {
+      Cognito.prototype.deleteUserPool.restore()
+      response.send.restore()
+    })
+
+    it('should delete the user pool', async () => {
+      const event = {
+        RequestType: 'Delete',
+        PhysicalResourceId: 'id',
+        ResourceProperties: {}
+      }
+      const deleteStub = sinon.stub(Cognito.prototype, 'deleteUserPool').returns()
+      const sendStub = sinon.stub(response, 'send').returns()
+
+      await handle(event, null, null)
+      assert(sendStub.calledOnce)
+      assert(sendStub.firstCall.args[2] === response.SUCCESS)
+      assert(deleteStub.calledOnce)
+      assert(deleteStub.firstCall.args[0] === event.PhysicalResourceId)
+    })
+  })
+})

--- a/packages/lambda/test/api/utils.js
+++ b/packages/lambda/test/api/utils.js
@@ -63,29 +63,11 @@ describe('SettingsProxy', () => {
     })
   })
 
-  describe('setAdminPageURL', () => {
-    it('should update the AdminPage URL and user pool and publish notification', async () => {
-      const proxy = new SettingsProxy()
-      proxy.store.setAdminPageURL = sinon.spy()
-      proxy.updateUserPool = sinon.spy()
-      proxy.sns.notifyIncident = sinon.spy()
-
-      const adminPageURL = 'https://example.com'
-      await proxy.setAdminPageURL(adminPageURL)
-
-      assert(proxy.settings.adminPageURL === adminPageURL)
-      assert(proxy.store.setAdminPageURL.calledOnce)
-      assert(proxy.store.setAdminPageURL.firstCall.args[0] === adminPageURL)
-      assert(proxy.updateUserPool.calledOnce)
-      assert(proxy.sns.notifyIncident.notCalled)
-    })
-  })
-
   describe('getAdminPageURL', () => {
-    it('should get the AdminPage URL from store if not cached', async () => {
+    it('should get the AdminPage URL from CloudFormation if not cached', async () => {
       const adminPageURL = 'https://example.com'
       const proxy = new SettingsProxy()
-      proxy.store.getAdminPageURL = async () => adminPageURL
+      proxy.cloudFormation.getAdminPageCloudFrontURL = async () => adminPageURL
 
       const actual = await proxy.getAdminPageURL()
       assert(adminPageURL === actual)

--- a/packages/lambda/test/api/utils.js
+++ b/packages/lambda/test/api/utils.js
@@ -86,29 +86,11 @@ describe('SettingsProxy', () => {
     })
   })
 
-  describe('setStatusPageURL', () => {
-    it('should update the StatusPage URL and user pool and publish notification', async () => {
-      const proxy = new SettingsProxy()
-      proxy.store.setStatusPageURL = sinon.spy()
-      proxy.updateUserPool = sinon.spy()
-      proxy.sns.notifyIncident = sinon.spy()
-
-      const statusPageURL = 'https://example.com'
-      await proxy.setStatusPageURL(statusPageURL)
-
-      assert(proxy.settings.statusPageURL === statusPageURL)
-      assert(proxy.store.setStatusPageURL.calledOnce)
-      assert(proxy.store.setStatusPageURL.firstCall.args[0] === statusPageURL)
-      assert(proxy.updateUserPool.notCalled)
-      assert(proxy.sns.notifyIncident.calledOnce)
-    })
-  })
-
   describe('getStatusPageURL', () => {
-    it('should get the StatusPage URL from store if not cached', async () => {
+    it('should get the StatusPage URL from CloudFormation if not cached', async () => {
       const statusPageURL = 'https://example.com'
       const proxy = new SettingsProxy()
-      proxy.store.getStatusPageURL = async () => statusPageURL
+      proxy.cloudFormation.getStatusPageCloudFrontURL = async () => statusPageURL
 
       const actual = await proxy.getStatusPageURL()
       assert(statusPageURL === actual)

--- a/packages/lambda/test/db/settings.js
+++ b/packages/lambda/test/db/settings.js
@@ -130,69 +130,6 @@ describe('SettingsStore', () => {
     })
   })
 
-  describe('getAdminPageURL', () => {
-    it('should return the AdminPage URL', async () => {
-      const url = 'test'
-      const store = new SettingsStore()
-      store.store.get = (key) => {
-        assert(key === settingKeys.adminPageURL)
-        return url
-      }
-
-      const actual = await store.getAdminPageURL()
-      assert(url === actual)
-    })
-
-    it('should pass through throwed error', async () => {
-      const store = new SettingsStore()
-      store.store.get = () => { throw new Error() }
-
-      let error
-      try {
-        await store.getAdminPageURL()
-      } catch (err) {
-        error = err
-      }
-      assert(error !== undefined)
-    })
-
-    it('should return empty string if not found', async () => {
-      const store = new SettingsStore()
-      store.store.get = () => { throw new NotFoundError() }
-
-      const actual = await store.getAdminPageURL()
-      assert(actual === '')
-    })
-  })
-
-  describe('setAdminPageURL', () => {
-    it('should set the AdminPage URL', async () => {
-      const url = 'test'
-      const store = new SettingsStore()
-      store.store.set = (key, value) => {
-        assert(key === settingKeys.adminPageURL)
-        assert(value === url)
-        return value
-      }
-
-      const actual = await store.setAdminPageURL(url)
-      assert(url === actual)
-    })
-
-    it('should pass through throwed error', async () => {
-      const store = new SettingsStore()
-      store.store.set = () => { throw new Error() }
-
-      let error
-      try {
-        await store.setAdminPageURL()
-      } catch (err) {
-        error = err
-      }
-      assert(error !== undefined)
-    })
-  })
-
   describe('getCognitoPoolID', () => {
     it('should return the CognitoPool ID', async () => {
       const id = 'test'

--- a/packages/lambda/test/db/settings.js
+++ b/packages/lambda/test/db/settings.js
@@ -67,69 +67,6 @@ describe('SettingsStore', () => {
     })
   })
 
-  describe('getStatusPageURL', () => {
-    it('should return the StatusPage URL', async () => {
-      const url = 'test'
-      const store = new SettingsStore()
-      store.store.get = (key) => {
-        assert(key === settingKeys.statusPageURL)
-        return url
-      }
-
-      const actual = await store.getStatusPageURL()
-      assert(url === actual)
-    })
-
-    it('should pass through throwed error', async () => {
-      const store = new SettingsStore()
-      store.store.get = () => { throw new Error() }
-
-      let error
-      try {
-        await store.getStatusPageURL()
-      } catch (err) {
-        error = err
-      }
-      assert(error !== undefined)
-    })
-
-    it('should return empty string if not found', async () => {
-      const store = new SettingsStore()
-      store.store.get = () => { throw new NotFoundError() }
-
-      const actual = await store.getStatusPageURL()
-      assert(actual === '')
-    })
-  })
-
-  describe('setStatusPageURL', () => {
-    it('should set the StatusPage URL', async () => {
-      const url = 'test'
-      const store = new SettingsStore()
-      store.store.set = (key, value) => {
-        assert(key === settingKeys.statusPageURL)
-        assert(value === url)
-        return value
-      }
-
-      const actual = await store.setStatusPageURL(url)
-      assert(url === actual)
-    })
-
-    it('should pass through throwed error', async () => {
-      const store = new SettingsStore()
-      store.store.set = () => { throw new Error() }
-
-      let error
-      try {
-        await store.setStatusPageURL()
-      } catch (err) {
-        error = err
-      }
-      assert(error !== undefined)
-    })
-  })
-
   describe('getCognitoPoolID', () => {
     it('should return the CognitoPool ID', async () => {
       const id = 'test'

--- a/packages/lambda/test/model/settings.js
+++ b/packages/lambda/test/model/settings.js
@@ -1,22 +1,2 @@
-import assert from 'assert'
-import { Settings } from 'model/settings'
-
 describe('Settings', () => {
-  describe('validate', () => {
-    it('should return true if the URL is valid', async () => {
-      const settings = new Settings()
-      const urls = ['https://example.com', 'http://example.com', 'example.com', 'https://example.com/test']
-      urls.forEach(url => {
-        assert(settings.validate(url))
-      })
-    })
-
-    it('should return false if the URL is invalid', async () => {
-      const settings = new Settings()
-      const urls = ['https://', '', 'https://example']
-      urls.forEach(url => {
-        assert(!settings.validate(url))
-      })
-    })
-  })
 })


### PR DESCRIPTION
This PR allows us to serve our status page with a custom domain such `status.example.com`. See the [wiki page](https://github.com/ks888/LambStatus/wiki/Set-up-your-custom-domain) for details.