### PR TITLE
Enforce non-email address in username

### DIFF
--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -3,10 +3,11 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: "AWS resources for serverless status pages"
 Parameters:
   UserName:
-    Description: Your user name
+    Description: Your user name (email addresses are not allowed).
     Type: String
     Default: admin
     MinLength: 1
+    AllowedPattern: "^[a-zA-Z0-9_-]*$"
   UserEmail:
     Description: Your email address. The initial login information will be sent to the address.
     Type: String


### PR DESCRIPTION
If an email address is used the cloud formation does not create properly due to an error related to cognito.

![screen shot 2017-11-25 at 1 30 01 pm](https://user-images.githubusercontent.com/9585787/33228114-11ba2720-d1e6-11e7-834d-ceff6248bbe4.png)
