### PR TITLE
Change Header's color based on Service status

### DIFF
--- a/packages/frontend/src/components/statusPage/Statuses/Statuses.js
+++ b/packages/frontend/src/components/statusPage/Statuses/Statuses.js
@@ -25,7 +25,7 @@ export default class Statuses extends React.Component {
     return (
       <div>
         <div className={classnames(classes.top)}>
-          <Title service_name={this.props.settings.serviceName} />
+          <Title />
           <SubscribeButton />
         </div>
         {components}

--- a/packages/frontend/src/components/statusPage/Title/Title.js
+++ b/packages/frontend/src/components/statusPage/Title/Title.js
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react'
+import classes from './Title.scss'
+
+export const Title = (props) => (
+  <h4>
+    <span className={classes.service_name}>{props.serviceName}</span>
+    <span style={{ color: props.statusColor }}> Status</span>
+  </h4>
+)
+
+Title.propTypes = {
+  serviceName: PropTypes.string,
+  statusColor: PropTypes.string
+}
+export default Title

--- a/packages/frontend/src/components/statusPage/Title/Title.scss
+++ b/packages/frontend/src/components/statusPage/Title/Title.scss
@@ -1,7 +1,3 @@
 .service_name {
   font-weight: 500;
 }
-
-.status {
-  color: rgb(56, 142, 60);
-}

--- a/packages/frontend/src/components/statusPage/Title/index.js
+++ b/packages/frontend/src/components/statusPage/Title/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { getComponentColor } from 'utils/status';
+import { getComponentColor } from 'utils/status'
 
 import Title from './Title'
 
@@ -13,7 +13,7 @@ const mapStateToProps = (state) => {
   }
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps (dispatch) {
   return bindActionCreators({}, dispatch)
 }
 

--- a/packages/frontend/src/components/statusPage/Title/index.js
+++ b/packages/frontend/src/components/statusPage/Title/index.js
@@ -1,14 +1,20 @@
-import React, { PropTypes } from 'react'
-import classes from './Title.scss'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import { getComponentColor } from 'utils/status';
 
-export const Title = (props) => (
-  <h4>
-    <span className={classes.service_name}>{props.service_name}</span>
-    <span className={classes.status}> Status</span>
-  </h4>
-)
+import Title from './Title'
 
-Title.propTypes = {
-  service_name: PropTypes.string
+const anyMajorOutage = (components) => !!components.filter(component => component.status === 'Major Outage').length
+
+const mapStateToProps = (state) => {
+  return {
+    serviceName: state.settings.settings.serviceName,
+    statusColor: getComponentColor(anyMajorOutage(state.components.components) ? 'Major Outage' : 'Operational')
+  }
 }
-export default Title
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({}, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Title)


### PR DESCRIPTION
This will make the Header color red if there is any component on status 'Major outage', green otherwise.

Closes #61