### PR TITLE
Close down buckets

### DIFF
--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -3687,19 +3687,6 @@ Resources:
               - "*"
       WebsiteConfiguration:
         IndexDocument: "index.html"
-  StatusPageS3BucketPolicy:
-    Type: "AWS::S3::BucketPolicy"
-    Properties:
-      Bucket:
-        Ref: "StatusPageS3"
-      PolicyDocument:
-        Statement:
-          - Effect: "Allow"
-            Action:
-              - "s3:GetObject"
-            Principal: "*"
-            Resource: !Sub |-
-              arn:aws:s3:::${StatusPageS3}/*
   StatusPageDistribution:
     Type: "AWS::CloudFront::Distribution"
     Properties:
@@ -3785,19 +3772,6 @@ Resources:
     Properties:
       WebsiteConfiguration:
         IndexDocument: "index.html"
-  AdminPageS3BucketPolicy:
-    Type: "AWS::S3::BucketPolicy"
-    Properties:
-      Bucket:
-        Ref: "AdminPageS3"
-      PolicyDocument:
-        Statement:
-          - Effect: "Allow"
-            Action:
-              - "s3:GetObject"
-            Principal: "*"
-            Resource: !Sub |-
-              arn:aws:s3:::${AdminPageS3}/*
   AdminPageDistribution:
     Type: "AWS::CloudFront::Distribution"
     Properties:
@@ -4181,6 +4155,7 @@ Resources:
       Bucket:
         Ref: StatusPageS3
       Key: settings.js
+      Acl: public-read
       Body: !Sub
         - __LAMBSTATUS_API_URL__ = 'https://${Domain}';
         - Domain: !If
@@ -4200,6 +4175,7 @@ Resources:
       Bucket:
         Ref: AdminPageS3
       Key: settings.js
+      Acl: public-read
       Body: !Sub
         - __LAMBSTATUS_API_URL__ = 'https://${Domain}';__LAMBSTATUS_USER_POOL_ID__ = '${CognitoUserPool.UserPoolID}';__LAMBSTATUS_CLIENT_ID__ = '${CognitoUserPoolClient.UserPoolClientID}';
         - Domain: !If
@@ -4234,6 +4210,7 @@ Resources:
         ${AWS::Region}
       DestinationBucket:
         Ref: StatusPageS3
+      Acl: public-read
   AdminPageFrontend:
     Type: Custom::S3SyncObjects
     Properties:
@@ -4250,6 +4227,7 @@ Resources:
         ${AWS::Region}
       DestinationBucket:
         Ref: AdminPageS3
+      Acl: public-read
   CognitoSMSCallerRole:
     Type: AWS::IAM::Role
     Properties:

--- a/packages/lambda/src/api/postLogos/index.js
+++ b/packages/lambda/src/api/postLogos/index.js
@@ -18,7 +18,7 @@ export async function handle (event, context, callback) {
       const body = await image.toBuffer()
 
       const objectName = `${imageID}${image.suffixForImageName()}`
-      await new S3().putObject(region, bucketName, objectName, body, image.mimeType)
+      await new S3().putObject(region, bucketName, objectName, body, image.mimeType, undefined, 'public-read')
     }
 
     await new SettingsProxy().setLogoID(imageID)

--- a/packages/lambda/src/api/s3PutObjects/index.js
+++ b/packages/lambda/src/api/s3PutObjects/index.js
@@ -9,12 +9,12 @@ export async function handle (event, context, callback) {
   }
 
   const params = event.ResourceProperties
-  const {Region: region, Bucket: bucket, Key: key, Body: body, CacheControl: cacheControl} = params
-  console.log(`received request (region: ${region}, bucket name: ${bucket}, key: ${key})`)
+  const {Region: region, Bucket: bucket, Key: key, Body: body, CacheControl: cacheControl, Acl: acl} = params
+  console.log(`received request (region: ${region}, bucket name: ${bucket}, key: ${key}, acl: ${acl})`)
 
   try {
     const s3 = new S3()
-    await s3.putObject(region, bucket, key, body, undefined, cacheControl)
+    await s3.putObject(region, bucket, key, body, undefined, cacheControl, acl)
     await Response.sendSuccess(event, context)
   } catch (error) {
     console.log(error.message)

--- a/packages/lambda/src/api/s3SyncObjects/index.js
+++ b/packages/lambda/src/api/s3SyncObjects/index.js
@@ -18,14 +18,15 @@ export async function handle (event, context, callback) {
     SourceBucket,
     SourceKey,
     DestinationRegion: region,
-    DestinationBucket
+    DestinationBucket,
+    Acl: acl
   } = params
   try {
     const s3 = new S3()
     const objects = await s3.listObjects(region, SourceBucket, SourceKey)
     await Promise.all(objects.map(async (obj) => {
       const destKey = obj.Key.replace(SourceKey + '/', '')
-      await s3.copyObject(region, SourceBucket, obj.Key, DestinationBucket, destKey)
+      await s3.copyObject(region, SourceBucket, obj.Key, DestinationBucket, destKey, acl)
     }))
     await Response.sendSuccess(event, context)
   } catch (error) {

--- a/packages/lambda/src/api/updateFeeds/index.js
+++ b/packages/lambda/src/api/updateFeeds/index.js
@@ -21,8 +21,8 @@ export async function handle (event, context, callback) {
     const { AWS_REGION: region } = process.env
     const bucket = await cloudFormation.getStatusPageBucketName()
     const s3 = new S3()
-    await s3.putObject(region, bucket, 'history.atom', feed.atom1())
-    await s3.putObject(region, bucket, 'history.rss', feed.rss2())
+    await s3.putObject(region, bucket, 'history.atom', feed.atom1(), undefined, undefined, 'public-read')
+    await s3.putObject(region, bucket, 'history.rss', feed.rss2(), undefined, undefined, 'public-read')
     callback(null)
   } catch (error) {
     console.log(error.message)

--- a/packages/lambda/src/api/utils.js
+++ b/packages/lambda/src/api/utils.js
@@ -240,7 +240,7 @@ export class MetricProxy extends Metric {
 
     const objectName = this.buildObjectName(this.metricID, date)
     const bucketName = await this.getBucketName()
-    await this.s3.putObject(region, bucketName, objectName, JSON.stringify(datapoints))
+    await this.s3.putObject(region, bucketName, objectName, JSON.stringify(datapoints), 'public-read')
   }
 
   async insertDatapoints (datapoints) {

--- a/packages/lambda/src/aws/s3.js
+++ b/packages/lambda/src/aws/s3.js
@@ -19,7 +19,7 @@ export default class S3 {
     })
   }
 
-  putObject (region, bucketName, objectName, body, mimeType = undefined, cacheControl = undefined) {
+  putObject (region, bucketName, objectName, body, mimeType = undefined, cacheControl = undefined, acl = undefined) {
     const awsS3 = new AWS.S3({ region })
     return new Promise((resolve, reject) => {
       if (mimeType === undefined) {
@@ -33,7 +33,8 @@ export default class S3 {
         Body: body,
         Key: objectName,
         ContentType: mimeType,
-        CacheControl: cacheControl
+        CacheControl: cacheControl,
+        ACL: acl
       }
       awsS3.putObject(params, (err, result) => {
         if (err) {
@@ -61,7 +62,7 @@ export default class S3 {
     })
   }
 
-  copyObject (region, srcBucketName, srcObjectName, destBucketName, destObjectName) {
+  copyObject (region, srcBucketName, srcObjectName, destBucketName, destObjectName, acl = undefined) {
     const awsS3 = new AWS.S3({ region })
     return new Promise((resolve, reject) => {
       const contentType = mime.lookup(destObjectName)
@@ -72,7 +73,8 @@ export default class S3 {
         ContentType: contentType,
         CacheControl: cacheControl,
         CopySource: srcBucketName + '/' + srcObjectName,
-        MetadataDirective: 'REPLACE'
+        MetadataDirective: 'REPLACE',
+        ACL: acl
       }
       awsS3.copyObject(params, (err, result) => {
         if (err) {

--- a/packages/lambda/test/api/postLogos/index.js
+++ b/packages/lambda/test/api/postLogos/index.js
@@ -39,6 +39,7 @@ describe('postLogos', () => {
     assert(putObjectStub.firstCall.args[1] === bucketName)
     assert(putObjectStub.firstCall.args[2].endsWith('@2x'))
     assert(putObjectStub.firstCall.args[4] === 'image/png')
+    assert(putObjectStub.firstCall.args[6] === 'public-read')
   })
 
   it('should save logo ID in the DB', async () => {

--- a/packages/lambda/test/api/updateFeeds/index.js
+++ b/packages/lambda/test/api/updateFeeds/index.js
@@ -58,9 +58,12 @@ describe('updateFeeds', () => {
 
     it('should put the feeds to s3 bucket', async () => {
       await handle(undefined, undefined, () => {})
+      console.log(putObjectStub.secondCall.args)
       assert(putObjectStub.callCount === 2)
       assert(putObjectStub.firstCall.args[2] === 'history.atom')
+      assert(putObjectStub.firstCall.args[6] === 'public-read')
       assert(putObjectStub.secondCall.args[2] === 'history.rss')
+      assert(putObjectStub.secondCall.args[6] === 'public-read')
     })
   })
 

--- a/packages/lambda/test/aws/s3.js
+++ b/packages/lambda/test/aws/s3.js
@@ -47,6 +47,7 @@ describe('S3', () => {
       const body = 'data'
       const contentType = 'text/html'
       const cacheControl = 'max-age=10'
+      const acl = 'public-read'
       let actual
       AWS.mock('S3', 'putObject', (params, callback) => {
         actual = params
@@ -54,13 +55,14 @@ describe('S3', () => {
       })
 
       const s3 = new S3()
-      await s3.putObject(undefined, bucketName, objectName, body)
+      await s3.putObject(undefined, bucketName, objectName, body, undefined, undefined, acl)
 
       assert(actual.Bucket === bucketName)
       assert(actual.Key === objectName)
       assert(actual.Body === body)
       assert(actual.ContentType === contentType)
       assert(actual.CacheControl === cacheControl)
+      assert(actual.ACL === acl)
     })
 
     it('should throw error if putObject fails ', async () => {
@@ -120,6 +122,7 @@ describe('S3', () => {
       const destObjectName = 'test.html'
       const contentType = 'text/html'
       const cacheControl = 'max-age=10'
+      const acl = 'public-read'
       let actual
       AWS.mock('S3', 'copyObject', (params, callback) => {
         actual = params
@@ -127,13 +130,14 @@ describe('S3', () => {
       })
 
       const s3 = new S3()
-      await s3.copyObject(undefined, srcBucketName, srcObjectName, destBucketName, destObjectName)
+      await s3.copyObject(undefined, srcBucketName, srcObjectName, destBucketName, destObjectName, acl)
 
       assert(actual.Bucket === destBucketName)
       assert(actual.Key === destObjectName)
       assert(actual.CopySource === srcBucketName + '/' + srcObjectName)
       assert(actual.ContentType === contentType)
       assert(actual.CacheControl === cacheControl)
+      assert(actual.ACL === acl)
     })
 
     it('should throw error if copyObject fails ', async () => {


### PR DESCRIPTION
This fixes #115 

Replace the permissive bucket policies with object ACLs.

Instead of having bucket policies that permit reading all objects in the buckets, upload the objects with ACLs that permit reading.

The primary motivation is that most security tools will complain loudly when you have permissive bucket policies. Even S3's console points out buckets with policies that allow anyone to read the contents.

By instead using object ACLs the intention is made more clear that these objects are in fact public – and it adds the possibility of uploading non-public objects, should that need arise in the future.

An alternative to this would be to [use an origin access identity to restrict the contents of the buckets to CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html), but with the object ACL method the S3 website hosting still works, which is nice.