### PR TITLE
Add AdminPageCloudFrontDomainName and StatusPageCloudFrontDomainName outputs

### DIFF
--- a/cloudformation/lamb-status.yml
+++ b/cloudformation/lamb-status.yml
@@ -4390,6 +4390,9 @@ Outputs:
         - UseDefaultAdminPageURL
         - !Sub ${AdminPageDistribution.DomainName}
         - !Select ["0", !Ref AdminPageURL]
+  AdminPageCloudFrontDomainName:
+    Value: !Sub |-
+      ${AdminPageDistribution.DomainName}
   StatusPageS3BucketURL:
     Value:
       Fn::GetAtt:
@@ -4406,6 +4409,9 @@ Outputs:
         - UseDefaultStatusPageURL
         - !Sub ${StatusPageDistribution.DomainName}
         - !Select ["0", !Ref StatusPageURL]
+  StatusPageCloudFrontDomainName:
+    Value: !Sub |-
+      ${StatusPageDistribution.DomainName}
   InvocationURL:
     Value: !Sub |-
       https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/prod/


### PR DESCRIPTION
This is to be able to use with external DNS provider (e.g. Cloudflare) if using custom URLs.

This is also to address some internal work on a terraform module that I may contribute back eventually to address https://github.com/ks888/LambStatus/issues/100.