### PR TITLE
Update package-lock version

### DIFF
--- a/packages/lambda/package-lock.json
+++ b/packages/lambda/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lamb-status-lambda",
-  "version": "0.6.2",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Because running `npm install` on a clean checkout is putting
the git repo in a dirty state.